### PR TITLE
fix: bind `this` correctly when destructuring `Redis` or `Pipeline`

### DIFF
--- a/pkg/pipeline.test.ts
+++ b/pkg/pipeline.test.ts
@@ -1,4 +1,5 @@
 import { Pipeline } from "./pipeline"
+import { Redis } from "./redis"
 import { keygen, newHttpClient } from "./test-utils"
 import { randomUUID } from "crypto"
 import { describe, it, expect, afterEach } from "@jest/globals"
@@ -6,6 +7,19 @@ const client = newHttpClient()
 
 const { newKey, cleanup } = keygen()
 afterEach(cleanup)
+
+describe("with destructuring", () => {
+  it("correctly binds this", async () => {
+    const { pipeline } = new Redis(client)
+    const p = pipeline()
+
+    const { echo, exec } = p
+    echo("Hello")
+
+    const res = await exec()
+    expect(res).toEqual(["Hello"])
+  })
+})
 
 describe("with single command", () => {
   it("works with multiple commands", async () => {

--- a/pkg/pipeline.ts
+++ b/pkg/pipeline.ts
@@ -176,7 +176,7 @@ export class Pipeline {
    * redis.pipeline().get("key").exec<[{ greeting: string }]>()
    * ```
    */
-  public async exec<TCommandResults extends unknown[] = unknown[]>(): Promise<TCommandResults> {
+  exec = async <TCommandResults extends unknown[] = unknown[]>(): Promise<TCommandResults> => {
     if (this.commands.length === 0) {
       throw new Error("Pipeline is empty")
     }
@@ -207,793 +207,615 @@ export class Pipeline {
   /**
    * @see https://redis.io/commands/append
    */
-  public append(...args: CommandArgs<typeof AppendCommand>): this {
-    return this.chain(new AppendCommand(...args))
-  }
+  append = (...args: CommandArgs<typeof AppendCommand>) => this.chain(new AppendCommand(...args))
 
   /**
    * @see https://redis.io/commands/bitcount
    */
-  public bitcount(...args: CommandArgs<typeof BitCountCommand>): this {
-    return this.chain(new BitCountCommand(...args))
-  }
+  bitcount = (...args: CommandArgs<typeof BitCountCommand>) =>
+    this.chain(new BitCountCommand(...args))
 
   /**
    * @see https://redis.io/commands/bitop
    */
-  public bitop(
-    op: "and" | "or" | "xor",
-    destinationKey: string,
-    sourceKey: string,
-    ...sourceKeys: string[]
-  ): this
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public bitop(op: "not", destinationKey: string, sourceKey: string): this
-
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public bitop(
+  bitop: {
+    (
+      op: "and" | "or" | "xor",
+      destinationKey: string,
+      sourceKey: string,
+      ...sourceKeys: string[]
+    ): Pipeline
+    (op: "not", destinationKey: string, sourceKey: string): Pipeline
+  } = (
     op: "and" | "or" | "xor" | "not",
     destinationKey: string,
     sourceKey: string,
     ...sourceKeys: string[]
-  ): this {
-    return this.chain(new BitOpCommand(op as any, destinationKey, sourceKey, ...sourceKeys))
-  }
+  ) => this.chain(new BitOpCommand(op as any, destinationKey, sourceKey, ...sourceKeys))
 
   /**
    * @see https://redis.io/commands/bitpos
    */
-  public bitpos(...args: CommandArgs<typeof BitPosCommand>): this {
-    return this.chain(new BitPosCommand(...args))
-  }
+  bitpos = (...args: CommandArgs<typeof BitPosCommand>) => this.chain(new BitPosCommand(...args))
 
   /**
    * @see https://redis.io/commands/dbsize
    */
-  public dbsize(): this {
-    return this.chain(new DBSizeCommand())
-  }
+  dbsize = () => this.chain(new DBSizeCommand())
 
   /**
    * @see https://redis.io/commands/decr
    */
-  public decr(...args: CommandArgs<typeof DecrCommand>): this {
-    return this.chain(new DecrCommand(...args))
-  }
+  decr = (...args: CommandArgs<typeof DecrCommand>) => this.chain(new DecrCommand(...args))
 
   /**
    * @see https://redis.io/commands/decrby
    */
-  public decrby(...args: CommandArgs<typeof DecrByCommand>): this {
-    return this.chain(new DecrByCommand(...args))
-  }
+  decrby = (...args: CommandArgs<typeof DecrByCommand>) => this.chain(new DecrByCommand(...args))
 
   /**
    * @see https://redis.io/commands/del
    */
-  public del(...args: CommandArgs<typeof DelCommand>): this {
-    return this.chain(new DelCommand(...args))
-  }
+  del = (...args: CommandArgs<typeof DelCommand>) => this.chain(new DelCommand(...args))
 
   /**
    * @see https://redis.io/commands/echo
    */
-  public echo(...args: CommandArgs<typeof EchoCommand>): this {
-    return this.chain(new EchoCommand(...args))
-  }
+  echo = (...args: CommandArgs<typeof EchoCommand>) => this.chain(new EchoCommand(...args))
 
   /**
    * @see https://redis.io/commands/exists
    */
-  public exists(...args: CommandArgs<typeof ExistsCommand>): this {
-    return this.chain(new ExistsCommand(...args))
-  }
+  exists = (...args: CommandArgs<typeof ExistsCommand>) => this.chain(new ExistsCommand(...args))
 
   /**
    * @see https://redis.io/commands/expire
    */
-  public expire(...args: CommandArgs<typeof ExpireCommand>): this {
-    return this.chain(new ExpireCommand(...args))
-  }
+  expire = (...args: CommandArgs<typeof ExpireCommand>) => this.chain(new ExpireCommand(...args))
 
   /**
    * @see https://redis.io/commands/expireat
    */
-  public expireat(...args: CommandArgs<typeof ExpireAtCommand>): this {
-    return this.chain(new ExpireAtCommand(...args))
-  }
+  expireat = (...args: CommandArgs<typeof ExpireAtCommand>) =>
+    this.chain(new ExpireAtCommand(...args))
 
   /**
    * @see https://redis.io/commands/flushall
    */
-  public flushall(...args: CommandArgs<typeof FlushAllCommand>): this {
-    return this.chain(new FlushAllCommand(...args))
-  }
+  flushall = (...args: CommandArgs<typeof FlushAllCommand>) =>
+    this.chain(new FlushAllCommand(...args))
 
   /**
    * @see https://redis.io/commands/flushdb
    */
-  public flushdb(...args: CommandArgs<typeof FlushDBCommand>): this {
-    return this.chain(new FlushDBCommand(...args))
-  }
+  flushdb = (...args: CommandArgs<typeof FlushDBCommand>) => this.chain(new FlushDBCommand(...args))
 
   /**
    * @see https://redis.io/commands/get
    */
-  public get<TData>(...args: CommandArgs<typeof GetCommand>): this {
-    return this.chain(new GetCommand<TData>(...args))
-  }
+  get = <TData>(...args: CommandArgs<typeof GetCommand>) =>
+    this.chain(new GetCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/getbit
    */
-  public getbit(...args: CommandArgs<typeof GetBitCommand>): this {
-    return this.chain(new GetBitCommand(...args))
-  }
+  getbit = (...args: CommandArgs<typeof GetBitCommand>) => this.chain(new GetBitCommand(...args))
 
   /**
    * @see https://redis.io/commands/getrange
    */
-  public getrange(...args: CommandArgs<typeof GetRangeCommand>): this {
-    return this.chain(new GetRangeCommand(...args))
-  }
+  getrange = (...args: CommandArgs<typeof GetRangeCommand>) =>
+    this.chain(new GetRangeCommand(...args))
 
   /**
    * @see https://redis.io/commands/getset
    */
-  public getset<TData>(key: string, value: TData): this {
-    return this.chain(new GetSetCommand<TData>(key, value))
-  }
+  getset = <TData>(key: string, value: TData) => this.chain(new GetSetCommand<TData>(key, value))
 
   /**
    * @see https://redis.io/commands/hdel
    */
-  public hdel(...args: CommandArgs<typeof HDelCommand>): this {
-    return this.chain(new HDelCommand(...args))
-  }
+  hdel = (...args: CommandArgs<typeof HDelCommand>) => this.chain(new HDelCommand(...args))
 
   /**
    * @see https://redis.io/commands/hexists
    */
-  public hexists(...args: CommandArgs<typeof HExistsCommand>): this {
-    return this.chain(new HExistsCommand(...args))
-  }
+  hexists = (...args: CommandArgs<typeof HExistsCommand>) => this.chain(new HExistsCommand(...args))
 
   /**
    * @see https://redis.io/commands/hget
    */
-  public hget<TData>(...args: CommandArgs<typeof HGetCommand>): this {
-    return this.chain(new HGetCommand<TData>(...args))
-  }
+  hget = <TData>(...args: CommandArgs<typeof HGetCommand>) =>
+    this.chain(new HGetCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/hgetall
    */
-  public hgetall<TData extends Record<string, unknown>>(
-    ...args: CommandArgs<typeof HGetAllCommand>
-  ): this {
-    return this.chain(new HGetAllCommand<TData>(...args))
-  }
+  hgetall = <TData extends Record<string, unknown>>(...args: CommandArgs<typeof HGetAllCommand>) =>
+    this.chain(new HGetAllCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/hincrby
    */
-  public hincrby(...args: CommandArgs<typeof HIncrByCommand>): this {
-    return this.chain(new HIncrByCommand(...args))
-  }
+  hincrby = (...args: CommandArgs<typeof HIncrByCommand>) => this.chain(new HIncrByCommand(...args))
 
   /**
    * @see https://redis.io/commands/hincrbyfloat
    */
-  public hincrbyfloat(...args: CommandArgs<typeof HIncrByFloatCommand>): this {
-    return this.chain(new HIncrByFloatCommand(...args))
-  }
+  hincrbyfloat = (...args: CommandArgs<typeof HIncrByFloatCommand>) =>
+    this.chain(new HIncrByFloatCommand(...args))
 
   /**
    * @see https://redis.io/commands/hkeys
    */
-  public hkeys(...args: CommandArgs<typeof HKeysCommand>): this {
-    return this.chain(new HKeysCommand(...args))
-  }
+  hkeys = (...args: CommandArgs<typeof HKeysCommand>) => this.chain(new HKeysCommand(...args))
 
   /**
    * @see https://redis.io/commands/hlen
    */
-  public hlen(...args: CommandArgs<typeof HLenCommand>): this {
-    return this.chain(new HLenCommand(...args))
-  }
+  hlen = (...args: CommandArgs<typeof HLenCommand>) => this.chain(new HLenCommand(...args))
 
   /**
    * @see https://redis.io/commands/hmget
    */
-  public hmget<TData extends Record<string, unknown>>(
-    ...args: CommandArgs<typeof HMGetCommand>
-  ): this {
-    return this.chain(new HMGetCommand<TData>(...args))
-  }
+  hmget = <TData extends Record<string, unknown>>(...args: CommandArgs<typeof HMGetCommand>) =>
+    this.chain(new HMGetCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/hmset
    */
-  public hmset<TData>(key: string, kv: { [field: string]: TData }): this {
-    return this.chain(new HMSetCommand(key, kv))
-  }
+  hmset = <TData>(key: string, kv: { [field: string]: TData }) =>
+    this.chain(new HMSetCommand(key, kv))
 
   /**
    * @see https://redis.io/commands/hscan
    */
-  public hscan(...args: CommandArgs<typeof HScanCommand>): this {
-    return this.chain(new HScanCommand(...args))
-  }
+  hscan = (...args: CommandArgs<typeof HScanCommand>) => this.chain(new HScanCommand(...args))
 
   /**
    * @see https://redis.io/commands/hset
    */
-  public hset<TData>(key: string, kv: { [field: string]: TData }): this {
-    return this.chain(new HSetCommand<TData>(key, kv))
-  }
+  hset = <TData>(key: string, kv: { [field: string]: TData }) =>
+    this.chain(new HSetCommand<TData>(key, kv))
 
   /**
    * @see https://redis.io/commands/hsetnx
    */
-  public hsetnx<TData>(key: string, field: string, value: TData): this {
-    return this.chain(new HSetNXCommand<TData>(key, field, value))
-  }
+  hsetnx = <TData>(key: string, field: string, value: TData) =>
+    this.chain(new HSetNXCommand<TData>(key, field, value))
 
   /**
    * @see https://redis.io/commands/hstrlen
    */
-  public hstrlen(...args: CommandArgs<typeof HStrLenCommand>): this {
-    return this.chain(new HStrLenCommand(...args))
-  }
+  hstrlen = (...args: CommandArgs<typeof HStrLenCommand>) => this.chain(new HStrLenCommand(...args))
 
   /**
    * @see https://redis.io/commands/hvals
    */
-  public hvals(...args: CommandArgs<typeof HValsCommand>): this {
-    return this.chain(new HValsCommand(...args))
-  }
+  hvals = (...args: CommandArgs<typeof HValsCommand>) => this.chain(new HValsCommand(...args))
 
   /**
    * @see https://redis.io/commands/incr
    */
-  public incr(...args: CommandArgs<typeof IncrCommand>): this {
-    return this.chain(new IncrCommand(...args))
-  }
+  incr = (...args: CommandArgs<typeof IncrCommand>) => this.chain(new IncrCommand(...args))
 
   /**
    * @see https://redis.io/commands/incrby
    */
-  public incrby(...args: CommandArgs<typeof IncrByCommand>): this {
-    return this.chain(new IncrByCommand(...args))
-  }
+  incrby = (...args: CommandArgs<typeof IncrByCommand>) => this.chain(new IncrByCommand(...args))
 
   /**
    * @see https://redis.io/commands/incrbyfloat
    */
-  public incrbyfloat(...args: CommandArgs<typeof IncrByFloatCommand>): this {
-    return this.chain(new IncrByFloatCommand(...args))
-  }
+  incrbyfloat = (...args: CommandArgs<typeof IncrByFloatCommand>) =>
+    this.chain(new IncrByFloatCommand(...args))
 
   /**
    * @see https://redis.io/commands/keys
    */
-  public keys(...args: CommandArgs<typeof KeysCommand>): this {
-    return this.chain(new KeysCommand(...args))
-  }
+  keys = (...args: CommandArgs<typeof KeysCommand>) => this.chain(new KeysCommand(...args))
 
   /**
    * @see https://redis.io/commands/lindex
    */
-  public lindex(...args: CommandArgs<typeof LIndexCommand>): this {
-    return this.chain(new LIndexCommand(...args))
-  }
+  lindex = (...args: CommandArgs<typeof LIndexCommand>) => this.chain(new LIndexCommand(...args))
 
   /**
    * @see https://redis.io/commands/linsert
    */
-  public linsert<TData>(
-    key: string,
-    direction: "before" | "after",
-    pivot: TData,
-    value: TData,
-  ): this {
-    return this.chain(new LInsertCommand<TData>(key, direction, pivot, value))
-  }
+  linsert = <TData>(key: string, direction: "before" | "after", pivot: TData, value: TData) =>
+    this.chain(new LInsertCommand<TData>(key, direction, pivot, value))
 
   /**
    * @see https://redis.io/commands/llen
    */
-  public llen(...args: CommandArgs<typeof LLenCommand>): this {
-    return this.chain(new LLenCommand(...args))
-  }
+  llen = (...args: CommandArgs<typeof LLenCommand>) => this.chain(new LLenCommand(...args))
 
   /**
    * @see https://redis.io/commands/lpop
    */
-  public lpop<TData>(...args: CommandArgs<typeof LPopCommand>): this {
-    return this.chain(new LPopCommand<TData>(...args))
-  }
+  lpop = <TData>(...args: CommandArgs<typeof LPopCommand>) =>
+    this.chain(new LPopCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/lpush
    */
-  public lpush<TData>(key: string, ...elements: NonEmptyArray<TData>): this {
-    return this.chain(new LPushCommand<TData>(key, ...elements))
-  }
+  lpush = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    this.chain(new LPushCommand<TData>(key, ...elements))
 
   /**
    * @see https://redis.io/commands/lpushx
    */
-  public lpushx<TData>(key: string, ...elements: NonEmptyArray<TData>): this {
-    return this.chain(new LPushXCommand<TData>(key, ...elements))
-  }
+  lpushx = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    this.chain(new LPushXCommand<TData>(key, ...elements))
 
   /**
    * @see https://redis.io/commands/lrange
    */
-  public lrange<TResult = string>(...args: CommandArgs<typeof LRangeCommand>): this {
-    return this.chain(new LRangeCommand<TResult>(...args))
-  }
+  lrange = <TResult = string>(...args: CommandArgs<typeof LRangeCommand>) =>
+    this.chain(new LRangeCommand<TResult>(...args))
 
   /**
    * @see https://redis.io/commands/lrem
    */
-  public lrem<TData>(key: string, count: number, value: TData): this {
-    return this.chain(new LRemCommand(key, count, value))
-  }
+  lrem = <TData>(key: string, count: number, value: TData) =>
+    this.chain(new LRemCommand(key, count, value))
 
   /**
    * @see https://redis.io/commands/lset
    */
-  public lset<TData>(key: string, value: TData, index: number): this {
-    return this.chain(new LSetCommand(key, value, index))
-  }
+  lset = <TData>(key: string, value: TData, index: number) =>
+    this.chain(new LSetCommand(key, value, index))
 
   /**
    * @see https://redis.io/commands/ltrim
    */
-  public ltrim(...args: CommandArgs<typeof LTrimCommand>): this {
-    return this.chain(new LTrimCommand(...args))
-  }
+  ltrim = (...args: CommandArgs<typeof LTrimCommand>) => this.chain(new LTrimCommand(...args))
 
   /**
    * @see https://redis.io/commands/mget
    */
-  public mget<TData extends [unknown, ...unknown[]]>(
-    ...args: CommandArgs<typeof MGetCommand>
-  ): this {
-    return this.chain(new MGetCommand<TData>(...args))
-  }
+  mget = <TData extends unknown[]>(...args: CommandArgs<typeof MGetCommand>) =>
+    this.chain(new MGetCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/mset
    */
-  public mset<TData>(kv: { [key: string]: TData }): this {
-    return this.chain(new MSetCommand<TData>(kv))
-  }
+  mset = <TData>(kv: { [key: string]: TData }) => this.chain(new MSetCommand<TData>(kv))
 
   /**
    * @see https://redis.io/commands/msetnx
    */
-  public msetnx<TData>(kv: { [key: string]: TData }): this {
-    return this.chain(new MSetNXCommand<TData>(kv))
-  }
+  msetnx = <TData>(kv: { [key: string]: TData }) => this.chain(new MSetNXCommand<TData>(kv))
 
   /**
    * @see https://redis.io/commands/persist
    */
-  public persist(...args: CommandArgs<typeof PersistCommand>): this {
-    return this.chain(new PersistCommand(...args))
-  }
+  persist = (...args: CommandArgs<typeof PersistCommand>) => this.chain(new PersistCommand(...args))
 
   /**
    * @see https://redis.io/commands/pexpire
    */
-  public pexpire(...args: CommandArgs<typeof PExpireCommand>): this {
-    return this.chain(new PExpireCommand(...args))
-  }
+  pexpire = (...args: CommandArgs<typeof PExpireCommand>) => this.chain(new PExpireCommand(...args))
 
   /**
    * @see https://redis.io/commands/pexpireat
    */
-  public pexpireat(...args: CommandArgs<typeof PExpireAtCommand>): this {
-    return this.chain(new PExpireAtCommand(...args))
-  }
+  pexpireat = (...args: CommandArgs<typeof PExpireAtCommand>) =>
+    this.chain(new PExpireAtCommand(...args))
 
   /**
    * @see https://redis.io/commands/ping
    */
-  public ping(...args: CommandArgs<typeof PingCommand>): this {
-    return this.chain(new PingCommand(...args))
-  }
+  ping = (...args: CommandArgs<typeof PingCommand>) => this.chain(new PingCommand(...args))
 
   /**
    * @see https://redis.io/commands/psetex
    */
-  public psetex<TData>(key: string, ttl: number, value: TData): this {
-    return this.chain(new PSetEXCommand<TData>(key, ttl, value))
-  }
+  psetex = <TData>(key: string, ttl: number, value: TData) =>
+    this.chain(new PSetEXCommand<TData>(key, ttl, value))
 
   /**
    * @see https://redis.io/commands/pttl
    */
-  public pttl(...args: CommandArgs<typeof PTtlCommand>): this {
-    return this.chain(new PTtlCommand(...args))
-  }
+  pttl = (...args: CommandArgs<typeof PTtlCommand>) => this.chain(new PTtlCommand(...args))
 
   /**
    * @see https://redis.io/commands/randomkey
    */
-  public randomkey(): this {
-    return this.chain(new RandomKeyCommand())
-  }
+  randomkey = () => this.chain(new RandomKeyCommand())
 
   /**
    * @see https://redis.io/commands/rename
    */
-  public rename(...args: CommandArgs<typeof RenameCommand>): this {
-    return this.chain(new RenameCommand(...args))
-  }
+  rename = (...args: CommandArgs<typeof RenameCommand>) => this.chain(new RenameCommand(...args))
 
   /**
    * @see https://redis.io/commands/renamenx
    */
-  public renamenx(...args: CommandArgs<typeof RenameNXCommand>): this {
-    return this.chain(new RenameNXCommand(...args))
-  }
+  renamenx = (...args: CommandArgs<typeof RenameNXCommand>) =>
+    this.chain(new RenameNXCommand(...args))
 
   /**
    * @see https://redis.io/commands/rpop
    */
-  public rpop<TData = string>(...args: CommandArgs<typeof RPopCommand>): this {
-    return this.chain(new RPopCommand<TData>(...args))
-  }
+  rpop = <TData = string>(...args: CommandArgs<typeof RPopCommand>) =>
+    this.chain(new RPopCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/rpush
    */
-  public rpush<TData>(key: string, ...elements: NonEmptyArray<TData>): this {
-    return this.chain(new RPushCommand(key, ...elements))
-  }
+  rpush = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    this.chain(new RPushCommand(key, ...elements))
 
   /**
    * @see https://redis.io/commands/rpushx
    */
-  public rpushx<TData>(key: string, ...elements: NonEmptyArray<TData>): this {
-    return this.chain(new RPushXCommand(key, ...elements))
-  }
+  rpushx = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    this.chain(new RPushXCommand(key, ...elements))
 
   /**
    * @see https://redis.io/commands/sadd
    */
-  public sadd<TData>(key: string, ...members: NonEmptyArray<TData>): this {
-    return this.chain(new SAddCommand<TData>(key, ...members))
-  }
+  sadd = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    this.chain(new SAddCommand<TData>(key, ...members))
 
   /**
    * @see https://redis.io/commands/scan
    */
-  public scan(...args: CommandArgs<typeof ScanCommand>): this {
-    return this.chain(new ScanCommand(...args))
-  }
+  scan = (...args: CommandArgs<typeof ScanCommand>) => this.chain(new ScanCommand(...args))
 
   /**
    * @see https://redis.io/commands/scard
    */
-  public scard(...args: CommandArgs<typeof SCardCommand>): this {
-    return this.chain(new SCardCommand(...args))
-  }
+  scard = (...args: CommandArgs<typeof SCardCommand>) => this.chain(new SCardCommand(...args))
 
   /**
    * @see https://redis.io/commands/sdiff
    */
-  public sdiff(...args: CommandArgs<typeof SDiffCommand>): this {
-    return this.chain(new SDiffCommand(...args))
-  }
+  sdiff = (...args: CommandArgs<typeof SDiffCommand>) => this.chain(new SDiffCommand(...args))
 
   /**
    * @see https://redis.io/commands/sdiffstore
    */
-  public sdiffstore(...args: CommandArgs<typeof SDiffStoreCommand>): this {
-    return this.chain(new SDiffStoreCommand(...args))
-  }
+  sdiffstore = (...args: CommandArgs<typeof SDiffStoreCommand>) =>
+    this.chain(new SDiffStoreCommand(...args))
 
   /**
    * @see https://redis.io/commands/set
    */
-  public set<TData>(key: string, value: TData, opts?: SetCommandOptions): this {
-    return this.chain(new SetCommand<TData>(key, value, opts))
-  }
+  set = <TData>(key: string, value: TData, opts?: SetCommandOptions) =>
+    this.chain(new SetCommand<TData>(key, value, opts))
 
   /**
    * @see https://redis.io/commands/setbit
    */
-  public setbit(...args: CommandArgs<typeof SetBitCommand>): this {
-    return this.chain(new SetBitCommand(...args))
-  }
+  setbit = (...args: CommandArgs<typeof SetBitCommand>) => this.chain(new SetBitCommand(...args))
 
   /**
    * @see https://redis.io/commands/setex
    */
-  public setex<TData>(key: string, ttl: number, value: TData): this {
-    return this.chain(new SetExCommand<TData>(key, ttl, value))
-  }
+  setex = <TData>(key: string, ttl: number, value: TData) =>
+    this.chain(new SetExCommand<TData>(key, ttl, value))
 
   /**
    * @see https://redis.io/commands/setnx
    */
-  public setnx<TData>(key: string, value: TData): this {
-    return this.chain(new SetNxCommand<TData>(key, value))
-  }
+  setnx = <TData>(key: string, value: TData) => this.chain(new SetNxCommand<TData>(key, value))
 
   /**
    * @see https://redis.io/commands/setrange
    */
-  public setrange(...args: CommandArgs<typeof SetRangeCommand>): this {
-    return this.chain(new SetRangeCommand(...args))
-  }
+  setrange = (...args: CommandArgs<typeof SetRangeCommand>) =>
+    this.chain(new SetRangeCommand(...args))
 
   /**
    * @see https://redis.io/commands/sinter
    */
-  public sinter(...args: CommandArgs<typeof SInterCommand>): this {
-    return this.chain(new SInterCommand(...args))
-  }
+  sinter = (...args: CommandArgs<typeof SInterCommand>) => this.chain(new SInterCommand(...args))
 
   /**
    * @see https://redis.io/commands/sinterstore
    */
-  public sinterstore(...args: CommandArgs<typeof SInterStoreCommand>): this {
-    return this.chain(new SInterStoreCommand(...args))
-  }
+  sinterstore = (...args: CommandArgs<typeof SInterStoreCommand>) =>
+    this.chain(new SInterStoreCommand(...args))
 
   /**
    * @see https://redis.io/commands/sismember
    */
-  public sismember<TData>(key: string, member: TData): this {
-    return this.chain(new SIsMemberCommand<TData>(key, member))
-  }
+  sismember = <TData>(key: string, member: TData) =>
+    this.chain(new SIsMemberCommand<TData>(key, member))
 
   /**
    * @see https://redis.io/commands/smembers
    */
-  public smembers(...args: CommandArgs<typeof SMembersCommand>): this {
-    return this.chain(new SMembersCommand(...args))
-  }
+  smembers = (...args: CommandArgs<typeof SMembersCommand>) =>
+    this.chain(new SMembersCommand(...args))
 
   /**
    * @see https://redis.io/commands/smove
    */
-  public smove<TData>(source: string, destination: string, member: TData): this {
-    return this.chain(new SMoveCommand<TData>(source, destination, member))
-  }
+  smove = <TData>(source: string, destination: string, member: TData) =>
+    this.chain(new SMoveCommand<TData>(source, destination, member))
 
   /**
    * @see https://redis.io/commands/spop
    */
-  public spop<TData>(...args: CommandArgs<typeof SPopCommand>): this {
-    return this.chain(new SPopCommand<TData>(...args))
-  }
+  spop = <TData>(...args: CommandArgs<typeof SPopCommand>) =>
+    this.chain(new SPopCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/srandmember
    */
-  public srandmember<TData>(...args: CommandArgs<typeof SRandMemberCommand>): this {
-    return this.chain(new SRandMemberCommand<TData>(...args))
-  }
+  srandmember = <TData>(...args: CommandArgs<typeof SRandMemberCommand>) =>
+    this.chain(new SRandMemberCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/srem
    */
-  public srem<TData>(key: string, ...members: NonEmptyArray<TData>): this {
-    return this.chain(new SRemCommand<TData>(key, ...members))
-  }
+  srem = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    this.chain(new SRemCommand<TData>(key, ...members))
 
   /**
    * @see https://redis.io/commands/sscan
    */
-  public sscan(...args: CommandArgs<typeof SScanCommand>): this {
-    return this.chain(new SScanCommand(...args))
-  }
+  sscan = (...args: CommandArgs<typeof SScanCommand>) => this.chain(new SScanCommand(...args))
 
   /**
    * @see https://redis.io/commands/strlen
    */
-  public strlen(...args: CommandArgs<typeof StrLenCommand>): this {
-    return this.chain(new StrLenCommand(...args))
-  }
+  strlen = (...args: CommandArgs<typeof StrLenCommand>) => this.chain(new StrLenCommand(...args))
 
   /**
    * @see https://redis.io/commands/sunion
    */
-  public sunion(...args: CommandArgs<typeof SUnionCommand>): this {
-    return this.chain(new SUnionCommand(...args))
-  }
+  sunion = (...args: CommandArgs<typeof SUnionCommand>) => this.chain(new SUnionCommand(...args))
+
   /**
    * @see https://redis.io/commands/sunionstore
    */
-  public sunionstore(...args: CommandArgs<typeof SUnionStoreCommand>): this {
-    return this.chain(new SUnionStoreCommand(...args))
-  }
+  sunionstore = (...args: CommandArgs<typeof SUnionStoreCommand>) =>
+    this.chain(new SUnionStoreCommand(...args))
 
   /**
    * @see https://redis.io/commands/time
    */
-  public time(): this {
-    return this.chain(new TimeCommand())
-  }
+  time = () => this.chain(new TimeCommand())
 
   /**
    * @see https://redis.io/commands/touch
    */
-  public touch(...args: CommandArgs<typeof TouchCommand>): this {
-    return this.chain(new TouchCommand(...args))
-  }
+  touch = (...args: CommandArgs<typeof TouchCommand>) => this.chain(new TouchCommand(...args))
 
   /**
    * @see https://redis.io/commands/ttl
    */
-  public ttl(...args: CommandArgs<typeof TtlCommand>): this {
-    return this.chain(new TtlCommand(...args))
-  }
+  ttl = (...args: CommandArgs<typeof TtlCommand>) => this.chain(new TtlCommand(...args))
 
   /**
    * @see https://redis.io/commands/type
    */
-  public type(...args: CommandArgs<typeof TypeCommand>): this {
-    return this.chain(new TypeCommand(...args))
-  }
+  type = (...args: CommandArgs<typeof TypeCommand>) => this.chain(new TypeCommand(...args))
 
   /**
    * @see https://redis.io/commands/unlink
    */
-  public unlink(...args: CommandArgs<typeof UnlinkCommand>): this {
-    return this.chain(new UnlinkCommand(...args))
-  }
+  unlink = (...args: CommandArgs<typeof UnlinkCommand>) => this.chain(new UnlinkCommand(...args))
 
   /**
    * @see https://redis.io/commands/zadd
    */
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public zadd<TData>(
-    key: string,
-    scoreMember: ScoreMember<TData>,
-    ...scoreMemberPairs: ScoreMember<TData>[]
-  ): this
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public zadd<TData>(
-    key: string,
-    opts: ZAddCommandOptions | ZAddCommandOptionsWithIncr,
-    ...scoreMemberPairs: [ScoreMember<TData>, ...ScoreMember<TData>[]]
-  ): this
-  // eslint-disable-next-line no-dupe-class-members
-  public zadd<TData>(
-    key: string,
-    arg1: ScoreMember<TData> | ZAddCommandOptions | ZAddCommandOptionsWithIncr,
-    ...arg2: ScoreMember<TData>[]
-  ): this {
-    // if ("score" in arg1) {
-    //   return this.chain(new ZAddCommand<TData>(key, arg1 as ScoreMember<TData>, ...arg2))
-    // }
-    return this.chain(new ZAddCommand<TData>(key, arg1 as any, ...arg2))
-  }
+  zadd = <TData>(
+    ...args:
+      | [key: string, scoreMember: ScoreMember<TData>, ...scoreMemberPairs: ScoreMember<TData>[]]
+      | [
+          key: string,
+          opts: ZAddCommandOptions | ZAddCommandOptionsWithIncr,
+          ...scoreMemberPairs: [ScoreMember<TData>, ...ScoreMember<TData>[]]
+        ]
+  ) => {
+    if ("score" in args[1]) {
+      return this.chain(
+        new ZAddCommand<TData>(args[0], args[1] as ScoreMember<TData>, ...(args.slice(2) as any)),
+      )
+    }
 
+    return this.chain(new ZAddCommand<TData>(args[0], args[1] as any, ...(args.slice(2) as any)))
+  }
   /**
    * @see https://redis.io/commands/zcard
    */
-  public zcard(...args: CommandArgs<typeof ZCardCommand>): this {
-    return this.chain(new ZCardCommand(...args))
-  }
+  zcard = (...args: CommandArgs<typeof ZCardCommand>) => this.chain(new ZCardCommand(...args))
 
   /**
    * @see https://redis.io/commands/zcount
    */
-  public zcount(...args: CommandArgs<typeof ZCountCommand>): this {
-    return this.chain(new ZCountCommand(...args))
-  }
+  zcount = (...args: CommandArgs<typeof ZCountCommand>) => this.chain(new ZCountCommand(...args))
 
   /**
    * @see https://redis.io/commands/zincrby
    */
-  public zincrby<TData>(key: string, increment: number, member: TData): this {
-    return this.chain(new ZIncrByComand<TData>(key, increment, member))
-  }
+  zincrby = <TData>(key: string, increment: number, member: TData) =>
+    this.chain(new ZIncrByComand<TData>(key, increment, member))
 
   /**
    * @see https://redis.io/commands/zinterstore
    */
-  public zinterstore(...args: CommandArgs<typeof ZInterStoreCommand>): this {
-    return this.chain(new ZInterStoreCommand(...args))
-  }
+  zinterstore = (...args: CommandArgs<typeof ZInterStoreCommand>) =>
+    this.chain(new ZInterStoreCommand(...args))
 
   /**
    * @see https://redis.io/commands/zlexcount
    */
-  public zlexcount(...args: CommandArgs<typeof ZLexCountCommand>): this {
-    return this.chain(new ZLexCountCommand(...args))
-  }
+  zlexcount = (...args: CommandArgs<typeof ZLexCountCommand>) =>
+    this.chain(new ZLexCountCommand(...args))
 
   /**
    * @see https://redis.io/commands/zpopmax
    */
-  public zpopmax<TData>(...args: CommandArgs<typeof ZPopMaxCommand>): this {
-    return this.chain(new ZPopMaxCommand<TData>(...args))
-  }
+  zpopmax = <TData>(...args: CommandArgs<typeof ZPopMaxCommand>) =>
+    this.chain(new ZPopMaxCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/zpopmin
    */
-  public zpopmin<TData>(...args: CommandArgs<typeof ZPopMinCommand>): this {
-    return this.chain(new ZPopMinCommand<TData>(...args))
-  }
+  zpopmin = <TData>(...args: CommandArgs<typeof ZPopMinCommand>) =>
+    this.chain(new ZPopMinCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/zrange
    */
-  public zrange<TData extends unknown[]>(...args: CommandArgs<typeof ZRangeCommand>): this {
-    return this.chain(new ZRangeCommand<TData>(...args))
-  }
+  zrange = <TData extends unknown[]>(...args: CommandArgs<typeof ZRangeCommand>) =>
+    this.chain(new ZRangeCommand<TData>(...args))
 
   /**
    * @see https://redis.io/commands/zrank
    */
-  public zrank<TData>(key: string, member: TData): this {
-    return this.chain(new ZRankCommand<TData>(key, member))
-  }
+  zrank = <TData>(key: string, member: TData) => this.chain(new ZRankCommand<TData>(key, member))
 
   /**
    * @see https://redis.io/commands/zrem
    */
-  public zrem<TData>(key: string, ...members: NonEmptyArray<TData>): this {
-    return this.chain(new ZRemCommand<TData>(key, ...members))
-  }
+  zrem = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    this.chain(new ZRemCommand<TData>(key, ...members))
 
   /**
    * @see https://redis.io/commands/zremrangebylex
    */
-  public zremrangebylex(...args: CommandArgs<typeof ZRemRangeByLexCommand>): this {
-    return this.chain(new ZRemRangeByLexCommand(...args))
-  }
+  zremrangebylex = (...args: CommandArgs<typeof ZRemRangeByLexCommand>) =>
+    this.chain(new ZRemRangeByLexCommand(...args))
 
   /**
    * @see https://redis.io/commands/zremrangebyrank
    */
-  public zremrangebyrank(...args: CommandArgs<typeof ZRemRangeByRankCommand>): this {
-    return this.chain(new ZRemRangeByRankCommand(...args))
-  }
+  zremrangebyrank = (...args: CommandArgs<typeof ZRemRangeByRankCommand>) =>
+    this.chain(new ZRemRangeByRankCommand(...args))
 
   /**
    * @see https://redis.io/commands/zremrangebyscore
    */
-  public zremrangebyscore(...args: CommandArgs<typeof ZRemRangeByScoreCommand>): this {
-    return this.chain(new ZRemRangeByScoreCommand(...args))
-  }
+  zremrangebyscore = (...args: CommandArgs<typeof ZRemRangeByScoreCommand>) =>
+    this.chain(new ZRemRangeByScoreCommand(...args))
 
   /**
    * @see https://redis.io/commands/zrevrank
    */
-  public zrevrank<TData>(key: string, member: TData): this {
-    return this.chain(new ZRevRankCommand<TData>(key, member))
-  }
+  zrevrank = <TData>(key: string, member: TData) =>
+    this.chain(new ZRevRankCommand<TData>(key, member))
 
   /**
    * @see https://redis.io/commands/zscan
    */
-  public zscan(...args: CommandArgs<typeof ZScanCommand>): this {
-    return this.chain(new ZScanCommand(...args))
-  }
+  zscan = (...args: CommandArgs<typeof ZScanCommand>) => this.chain(new ZScanCommand(...args))
 
   /**
    * @see https://redis.io/commands/zscore
    */
-  public zscore<TData>(key: string, member: TData): this {
-    return this.chain(new ZScoreCommand<TData>(key, member))
-  }
+  zscore = <TData>(key: string, member: TData) => this.chain(new ZScoreCommand<TData>(key, member))
+
   /**
    * @see https://redis.io/commands/zunionstore
    */
-  public zunionstore(...args: CommandArgs<typeof ZUnionStoreCommand>): this {
-    return this.chain(new ZUnionStoreCommand(...args))
-  }
+  zunionstore = (...args: CommandArgs<typeof ZUnionStoreCommand>) =>
+    this.chain(new ZUnionStoreCommand(...args))
 }

--- a/pkg/redis.test.ts
+++ b/pkg/redis.test.ts
@@ -1,0 +1,19 @@
+import { keygen, newHttpClient } from "./test-utils"
+import { randomUUID } from "crypto"
+import { describe, it, expect, afterEach } from "@jest/globals"
+import { Redis } from "./redis"
+const client = newHttpClient()
+
+const { newKey, cleanup } = keygen()
+afterEach(cleanup)
+
+describe("when destructuring the redis class", () => {
+  it("correctly binds this", async () => {
+    const { get, set } = new Redis(client)
+    const key = newKey()
+    const value = randomUUID()
+    await set(key, value)
+    const res = await get(key)
+    expect(res).toEqual(value)
+  })
+})

--- a/pkg/redis.ts
+++ b/pkg/redis.ts
@@ -140,791 +140,649 @@ export class Redis {
    *
    * @see {@link Pipeline}
    */
-  public pipeline(): Pipeline {
-    return new Pipeline(this.client)
-  }
+  pipeline = () => new Pipeline(this.client)
 
   /**
    * @see https://redis.io/commands/append
    */
-  public append(...args: CommandArgs<typeof AppendCommand>) {
-    return new AppendCommand(...args).exec(this.client)
-  }
+  append = (...args: CommandArgs<typeof AppendCommand>) =>
+    new AppendCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/bitcount
    */
-  public bitcount(...args: CommandArgs<typeof BitCountCommand>) {
-    return new BitCountCommand(...args).exec(this.client)
-  }
+  bitcount = (...args: CommandArgs<typeof BitCountCommand>) =>
+    new BitCountCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/bitop
    */
-  public bitop(
-    op: "and" | "or" | "xor",
-    destinationKey: string,
-    sourceKey: string,
-    ...sourceKeys: string[]
-  ): Promise<number>
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public bitop(op: "not", destinationKey: string, sourceKey: string): Promise<number>
-
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public bitop(
+  bitop: {
+    (
+      op: "and" | "or" | "xor",
+      destinationKey: string,
+      sourceKey: string,
+      ...sourceKeys: string[]
+    ): Promise<number>
+    (op: "not", destinationKey: string, sourceKey: string): Promise<number>
+  } = (
     op: "and" | "or" | "xor" | "not",
     destinationKey: string,
     sourceKey: string,
     ...sourceKeys: string[]
-  ) {
-    return new BitOpCommand(op as any, destinationKey, sourceKey, ...sourceKeys).exec(this.client)
-  }
+  ) => new BitOpCommand(op as any, destinationKey, sourceKey, ...sourceKeys).exec(this.client)
 
   /**
    * @see https://redis.io/commands/bitpos
    */
-  public bitpos(...args: CommandArgs<typeof BitPosCommand>) {
-    return new BitPosCommand(...args).exec(this.client)
-  }
+  bitpos = (...args: CommandArgs<typeof BitPosCommand>) =>
+    new BitPosCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/dbsize
    */
-  public dbsize() {
-    return new DBSizeCommand().exec(this.client)
-  }
+  dbsize = () => new DBSizeCommand().exec(this.client)
 
   /**
    * @see https://redis.io/commands/decr
    */
-  public decr(...args: CommandArgs<typeof DecrCommand>) {
-    return new DecrCommand(...args).exec(this.client)
-  }
+  decr = (...args: CommandArgs<typeof DecrCommand>) => new DecrCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/decrby
    */
-  public decrby(...args: CommandArgs<typeof DecrByCommand>) {
-    return new DecrByCommand(...args).exec(this.client)
-  }
+  decrby = (...args: CommandArgs<typeof DecrByCommand>) =>
+    new DecrByCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/del
    */
-  public del(...args: CommandArgs<typeof DelCommand>) {
-    return new DelCommand(...args).exec(this.client)
-  }
+  del = (...args: CommandArgs<typeof DelCommand>) => new DelCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/echo
    */
-  public echo(...args: CommandArgs<typeof EchoCommand>) {
-    return new EchoCommand(...args).exec(this.client)
-  }
+  echo = (...args: CommandArgs<typeof EchoCommand>) => new EchoCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/exists
    */
-  public exists(...args: CommandArgs<typeof ExistsCommand>) {
-    return new ExistsCommand(...args).exec(this.client)
-  }
+  exists = (...args: CommandArgs<typeof ExistsCommand>) =>
+    new ExistsCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/expire
    */
-  public expire(...args: CommandArgs<typeof ExpireCommand>) {
-    return new ExpireCommand(...args).exec(this.client)
-  }
+  expire = (...args: CommandArgs<typeof ExpireCommand>) =>
+    new ExpireCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/expireat
    */
-  public expireat(...args: CommandArgs<typeof ExpireAtCommand>) {
-    return new ExpireAtCommand(...args).exec(this.client)
-  }
+  expireat = (...args: CommandArgs<typeof ExpireAtCommand>) =>
+    new ExpireAtCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/flushall
    */
-  public flushall(...args: CommandArgs<typeof FlushAllCommand>) {
-    return new FlushAllCommand(...args).exec(this.client)
-  }
+  flushall = (...args: CommandArgs<typeof FlushAllCommand>) =>
+    new FlushAllCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/flushdb
    */
-  public flushdb(...args: CommandArgs<typeof FlushDBCommand>) {
-    return new FlushDBCommand(...args).exec(this.client)
-  }
+  flushdb = (...args: CommandArgs<typeof FlushDBCommand>) =>
+    new FlushDBCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/get
    */
-  public get<TData>(...args: CommandArgs<typeof GetCommand>) {
-    return new GetCommand<TData>(...args).exec(this.client)
-  }
+  get = <TData>(...args: CommandArgs<typeof GetCommand>) =>
+    new GetCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/getbit
    */
-  public getbit(...args: CommandArgs<typeof GetBitCommand>) {
-    return new GetBitCommand(...args).exec(this.client)
-  }
+  getbit = (...args: CommandArgs<typeof GetBitCommand>) =>
+    new GetBitCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/getrange
    */
-  public getrange(...args: CommandArgs<typeof GetRangeCommand>) {
-    return new GetRangeCommand(...args).exec(this.client)
-  }
+  getrange = (...args: CommandArgs<typeof GetRangeCommand>) =>
+    new GetRangeCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/getset
    */
-  public getset<TData>(key: string, value: TData) {
-    return new GetSetCommand<TData>(key, value).exec(this.client)
-  }
+  getset = <TData>(key: string, value: TData) =>
+    new GetSetCommand<TData>(key, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hdel
    */
-  public hdel(...args: CommandArgs<typeof HDelCommand>) {
-    return new HDelCommand(...args).exec(this.client)
-  }
+  hdel = (...args: CommandArgs<typeof HDelCommand>) => new HDelCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hexists
    */
-  public hexists(...args: CommandArgs<typeof HExistsCommand>) {
-    return new HExistsCommand(...args).exec(this.client)
-  }
+  hexists = (...args: CommandArgs<typeof HExistsCommand>) =>
+    new HExistsCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hget
    */
-  public hget<TData>(...args: CommandArgs<typeof HGetCommand>) {
-    return new HGetCommand<TData>(...args).exec(this.client)
-  }
+  hget = <TData>(...args: CommandArgs<typeof HGetCommand>) =>
+    new HGetCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hgetall
    */
-  public hgetall<TData extends Record<string, unknown>>(
-    ...args: CommandArgs<typeof HGetAllCommand>
-  ) {
-    return new HGetAllCommand<TData>(...args).exec(this.client)
-  }
+  hgetall = <TData extends Record<string, unknown>>(...args: CommandArgs<typeof HGetAllCommand>) =>
+    new HGetAllCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hincrby
    */
-  public hincrby(...args: CommandArgs<typeof HIncrByCommand>) {
-    return new HIncrByCommand(...args).exec(this.client)
-  }
+  hincrby = (...args: CommandArgs<typeof HIncrByCommand>) =>
+    new HIncrByCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hincrbyfloat
    */
-  public hincrbyfloat(...args: CommandArgs<typeof HIncrByFloatCommand>) {
-    return new HIncrByFloatCommand(...args).exec(this.client)
-  }
+  hincrbyfloat = (...args: CommandArgs<typeof HIncrByFloatCommand>) =>
+    new HIncrByFloatCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hkeys
    */
-  public hkeys(...args: CommandArgs<typeof HKeysCommand>) {
-    return new HKeysCommand(...args).exec(this.client)
-  }
+  hkeys = (...args: CommandArgs<typeof HKeysCommand>) => new HKeysCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hlen
    */
-  public hlen(...args: CommandArgs<typeof HLenCommand>) {
-    return new HLenCommand(...args).exec(this.client)
-  }
+  hlen = (...args: CommandArgs<typeof HLenCommand>) => new HLenCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hmget
    */
-  public hmget<TData extends Record<string, unknown>>(...args: CommandArgs<typeof HMGetCommand>) {
-    return new HMGetCommand<TData>(...args).exec(this.client)
-  }
+  hmget = <TData extends Record<string, unknown>>(...args: CommandArgs<typeof HMGetCommand>) =>
+    new HMGetCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hmset
    */
-  public hmset<TData>(key: string, kv: { [field: string]: TData }) {
-    return new HMSetCommand(key, kv).exec(this.client)
-  }
+  hmset = <TData>(key: string, kv: { [field: string]: TData }) =>
+    new HMSetCommand(key, kv).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hscan
    */
-  public hscan(...args: CommandArgs<typeof HScanCommand>) {
-    return new HScanCommand(...args).exec(this.client)
-  }
+  hscan = (...args: CommandArgs<typeof HScanCommand>) => new HScanCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hset
    */
-  public hset<TData>(key: string, kv: { [field: string]: TData }) {
-    return new HSetCommand<TData>(key, kv).exec(this.client)
-  }
+  hset = <TData>(key: string, kv: { [field: string]: TData }) =>
+    new HSetCommand<TData>(key, kv).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hsetnx
    */
-  public hsetnx<TData>(key: string, field: string, value: TData) {
-    return new HSetNXCommand<TData>(key, field, value).exec(this.client)
-  }
+  hsetnx = <TData>(key: string, field: string, value: TData) =>
+    new HSetNXCommand<TData>(key, field, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hstrlen
    */
-  public hstrlen(...args: CommandArgs<typeof HStrLenCommand>) {
-    return new HStrLenCommand(...args).exec(this.client)
-  }
+  hstrlen = (...args: CommandArgs<typeof HStrLenCommand>) =>
+    new HStrLenCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/hvals
    */
-  public hvals(...args: CommandArgs<typeof HValsCommand>) {
-    return new HValsCommand(...args).exec(this.client)
-  }
+  hvals = (...args: CommandArgs<typeof HValsCommand>) => new HValsCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/incr
    */
-  public incr(...args: CommandArgs<typeof IncrCommand>) {
-    return new IncrCommand(...args).exec(this.client)
-  }
+  incr = (...args: CommandArgs<typeof IncrCommand>) => new IncrCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/incrby
    */
-  public incrby(...args: CommandArgs<typeof IncrByCommand>) {
-    return new IncrByCommand(...args).exec(this.client)
-  }
+  incrby = (...args: CommandArgs<typeof IncrByCommand>) =>
+    new IncrByCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/incrbyfloat
    */
-  public incrbyfloat(...args: CommandArgs<typeof IncrByFloatCommand>) {
-    return new IncrByFloatCommand(...args).exec(this.client)
-  }
+  incrbyfloat = (...args: CommandArgs<typeof IncrByFloatCommand>) =>
+    new IncrByFloatCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/keys
    */
-  public keys(...args: CommandArgs<typeof KeysCommand>) {
-    return new KeysCommand(...args).exec(this.client)
-  }
+  keys = (...args: CommandArgs<typeof KeysCommand>) => new KeysCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lindex
    */
-  public lindex(...args: CommandArgs<typeof LIndexCommand>) {
-    return new LIndexCommand(...args).exec(this.client)
-  }
+  lindex = (...args: CommandArgs<typeof LIndexCommand>) =>
+    new LIndexCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/linsert
    */
-  public linsert<TData>(key: string, direction: "before" | "after", pivot: TData, value: TData) {
-    return new LInsertCommand<TData>(key, direction, pivot, value).exec(this.client)
-  }
+  linsert = <TData>(key: string, direction: "before" | "after", pivot: TData, value: TData) =>
+    new LInsertCommand<TData>(key, direction, pivot, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/llen
    */
-  public llen(...args: CommandArgs<typeof LLenCommand>) {
-    return new LLenCommand(...args).exec(this.client)
-  }
+  llen = (...args: CommandArgs<typeof LLenCommand>) => new LLenCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lpop
    */
-  public lpop<TData>(...args: CommandArgs<typeof LPopCommand>) {
-    return new LPopCommand<TData>(...args).exec(this.client)
-  }
+  lpop = <TData>(...args: CommandArgs<typeof LPopCommand>) =>
+    new LPopCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lpush
    */
-  public lpush<TData>(key: string, ...elements: NonEmptyArray<TData>) {
-    return new LPushCommand<TData>(key, ...elements).exec(this.client)
-  }
+  lpush = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    new LPushCommand<TData>(key, ...elements).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lpushx
    */
-  public lpushx<TData>(key: string, ...elements: NonEmptyArray<TData>) {
-    return new LPushXCommand<TData>(key, ...elements).exec(this.client)
-  }
+  lpushx = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    new LPushXCommand<TData>(key, ...elements).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lrange
    */
-  public lrange<TResult = string>(...args: CommandArgs<typeof LRangeCommand>) {
-    return new LRangeCommand<TResult>(...args).exec(this.client)
-  }
+  lrange = <TResult = string>(...args: CommandArgs<typeof LRangeCommand>) =>
+    new LRangeCommand<TResult>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lrem
    */
-  public lrem<TData>(key: string, count: number, value: TData) {
-    return new LRemCommand(key, count, value).exec(this.client)
-  }
+  lrem = <TData>(key: string, count: number, value: TData) =>
+    new LRemCommand(key, count, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/lset
    */
-  public lset<TData>(key: string, value: TData, index: number) {
-    return new LSetCommand(key, value, index).exec(this.client)
-  }
+  lset = <TData>(key: string, value: TData, index: number) =>
+    new LSetCommand(key, value, index).exec(this.client)
 
   /**
    * @see https://redis.io/commands/ltrim
    */
-  public ltrim(...args: CommandArgs<typeof LTrimCommand>) {
-    return new LTrimCommand(...args).exec(this.client)
-  }
+  ltrim = (...args: CommandArgs<typeof LTrimCommand>) => new LTrimCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/mget
    */
-  public mget<TData extends unknown[]>(...args: CommandArgs<typeof MGetCommand>) {
-    return new MGetCommand<TData>(...args).exec(this.client)
-  }
+  mget = <TData extends unknown[]>(...args: CommandArgs<typeof MGetCommand>) =>
+    new MGetCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/mset
    */
-  public mset<TData>(kv: { [key: string]: TData }) {
-    return new MSetCommand<TData>(kv).exec(this.client)
-  }
+  mset = <TData>(kv: { [key: string]: TData }) => new MSetCommand<TData>(kv).exec(this.client)
 
   /**
    * @see https://redis.io/commands/msetnx
    */
-  public msetnx<TData>(kv: { [key: string]: TData }) {
-    return new MSetNXCommand<TData>(kv).exec(this.client)
-  }
+  msetnx = <TData>(kv: { [key: string]: TData }) => new MSetNXCommand<TData>(kv).exec(this.client)
 
   /**
    * @see https://redis.io/commands/persist
    */
-  public persist(...args: CommandArgs<typeof PersistCommand>) {
-    return new PersistCommand(...args).exec(this.client)
-  }
+  persist = (...args: CommandArgs<typeof PersistCommand>) =>
+    new PersistCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/pexpire
    */
-  public pexpire(...args: CommandArgs<typeof PExpireCommand>) {
-    return new PExpireCommand(...args).exec(this.client)
-  }
+  pexpire = (...args: CommandArgs<typeof PExpireCommand>) =>
+    new PExpireCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/pexpireat
    */
-  public pexpireat(...args: CommandArgs<typeof PExpireAtCommand>) {
-    return new PExpireAtCommand(...args).exec(this.client)
-  }
+  pexpireat = (...args: CommandArgs<typeof PExpireAtCommand>) =>
+    new PExpireAtCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/ping
    */
-  public ping(...args: CommandArgs<typeof PingCommand>) {
-    return new PingCommand(...args).exec(this.client)
-  }
+  ping = (...args: CommandArgs<typeof PingCommand>) => new PingCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/psetex
    */
-  public psetex<TData>(key: string, ttl: number, value: TData) {
-    return new PSetEXCommand<TData>(key, ttl, value).exec(this.client)
-  }
+  psetex = <TData>(key: string, ttl: number, value: TData) =>
+    new PSetEXCommand<TData>(key, ttl, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/pttl
    */
-  public pttl(...args: CommandArgs<typeof PTtlCommand>) {
-    return new PTtlCommand(...args).exec(this.client)
-  }
+  pttl = (...args: CommandArgs<typeof PTtlCommand>) => new PTtlCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/randomkey
    */
-  public randomkey() {
-    return new RandomKeyCommand().exec(this.client)
-  }
+  randomkey = () => new RandomKeyCommand().exec(this.client)
 
   /**
    * @see https://redis.io/commands/rename
    */
-  public rename(...args: CommandArgs<typeof RenameCommand>) {
-    return new RenameCommand(...args).exec(this.client)
-  }
+  rename = (...args: CommandArgs<typeof RenameCommand>) =>
+    new RenameCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/renamenx
    */
-  public renamenx(...args: CommandArgs<typeof RenameNXCommand>) {
-    return new RenameNXCommand(...args).exec(this.client)
-  }
+  renamenx = (...args: CommandArgs<typeof RenameNXCommand>) =>
+    new RenameNXCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/rpop
    */
-  public rpop<TData = string>(...args: CommandArgs<typeof RPopCommand>) {
-    return new RPopCommand<TData>(...args).exec(this.client)
-  }
+  rpop = <TData = string>(...args: CommandArgs<typeof RPopCommand>) =>
+    new RPopCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/rpush
    */
-  public rpush<TData>(key: string, ...elements: NonEmptyArray<TData>) {
-    return new RPushCommand(key, ...elements).exec(this.client)
-  }
+  rpush = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    new RPushCommand(key, ...elements).exec(this.client)
 
   /**
    * @see https://redis.io/commands/rpushx
    */
-  public rpushx<TData>(key: string, ...elements: NonEmptyArray<TData>) {
-    return new RPushXCommand(key, ...elements).exec(this.client)
-  }
+  rpushx = <TData>(key: string, ...elements: NonEmptyArray<TData>) =>
+    new RPushXCommand(key, ...elements).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sadd
    */
-  public sadd<TData>(key: string, ...members: NonEmptyArray<TData>) {
-    return new SAddCommand<TData>(key, ...members).exec(this.client)
-  }
+  sadd = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    new SAddCommand<TData>(key, ...members).exec(this.client)
 
   /**
    * @see https://redis.io/commands/scan
    */
-  public scan(...args: CommandArgs<typeof ScanCommand>) {
-    return new ScanCommand(...args).exec(this.client)
-  }
+  scan = (...args: CommandArgs<typeof ScanCommand>) => new ScanCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/scard
    */
-  public scard(...args: CommandArgs<typeof SCardCommand>) {
-    return new SCardCommand(...args).exec(this.client)
-  }
+  scard = (...args: CommandArgs<typeof SCardCommand>) => new SCardCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sdiff
    */
-  public sdiff(...args: CommandArgs<typeof SDiffCommand>) {
-    return new SDiffCommand(...args).exec(this.client)
-  }
+  sdiff = (...args: CommandArgs<typeof SDiffCommand>) => new SDiffCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sdiffstore
    */
-  public sdiffstore(...args: CommandArgs<typeof SDiffStoreCommand>) {
-    return new SDiffStoreCommand(...args).exec(this.client)
-  }
+  sdiffstore = (...args: CommandArgs<typeof SDiffStoreCommand>) =>
+    new SDiffStoreCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/set
    */
-  public set<TData>(key: string, value: TData, opts?: SetCommandOptions) {
-    return new SetCommand<TData>(key, value, opts).exec(this.client)
-  }
+  set = <TData>(key: string, value: TData, opts?: SetCommandOptions) =>
+    new SetCommand<TData>(key, value, opts).exec(this.client)
 
   /**
    * @see https://redis.io/commands/setbit
    */
-  public setbit(...args: CommandArgs<typeof SetBitCommand>) {
-    return new SetBitCommand(...args).exec(this.client)
-  }
+  setbit = (...args: CommandArgs<typeof SetBitCommand>) =>
+    new SetBitCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/setex
    */
-  public setex<TData>(key: string, ttl: number, value: TData) {
-    return new SetExCommand<TData>(key, ttl, value).exec(this.client)
-  }
+  setex = <TData>(key: string, ttl: number, value: TData) =>
+    new SetExCommand<TData>(key, ttl, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/setnx
    */
-  public setnx<TData>(key: string, value: TData) {
-    return new SetNxCommand<TData>(key, value).exec(this.client)
-  }
+  setnx = <TData>(key: string, value: TData) =>
+    new SetNxCommand<TData>(key, value).exec(this.client)
 
   /**
    * @see https://redis.io/commands/setrange
    */
-  public setrange(...args: CommandArgs<typeof SetRangeCommand>) {
-    return new SetRangeCommand(...args).exec(this.client)
-  }
+  setrange = (...args: CommandArgs<typeof SetRangeCommand>) =>
+    new SetRangeCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sinter
    */
-  public sinter(...args: CommandArgs<typeof SInterCommand>) {
-    return new SInterCommand(...args).exec(this.client)
-  }
+  sinter = (...args: CommandArgs<typeof SInterCommand>) =>
+    new SInterCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sinterstore
    */
-  public sinterstore(...args: CommandArgs<typeof SInterStoreCommand>) {
-    return new SInterStoreCommand(...args).exec(this.client)
-  }
+  sinterstore = (...args: CommandArgs<typeof SInterStoreCommand>) =>
+    new SInterStoreCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sismember
    */
-  public sismember<TData>(key: string, member: TData) {
-    return new SIsMemberCommand<TData>(key, member).exec(this.client)
-  }
+  sismember = <TData>(key: string, member: TData) =>
+    new SIsMemberCommand<TData>(key, member).exec(this.client)
 
   /**
    * @see https://redis.io/commands/smembers
    */
-  public smembers(...args: CommandArgs<typeof SMembersCommand>) {
-    return new SMembersCommand(...args).exec(this.client)
-  }
+  smembers = (...args: CommandArgs<typeof SMembersCommand>) =>
+    new SMembersCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/smove
    */
-  public smove<TData>(source: string, destination: string, member: TData) {
-    return new SMoveCommand<TData>(source, destination, member).exec(this.client)
-  }
+  smove = <TData>(source: string, destination: string, member: TData) =>
+    new SMoveCommand<TData>(source, destination, member).exec(this.client)
 
   /**
    * @see https://redis.io/commands/spop
    */
-  public spop<TData>(...args: CommandArgs<typeof SPopCommand>) {
-    return new SPopCommand<TData>(...args).exec(this.client)
-  }
+  spop = <TData>(...args: CommandArgs<typeof SPopCommand>) =>
+    new SPopCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/srandmember
    */
-  public srandmember<TData>(...args: CommandArgs<typeof SRandMemberCommand>) {
-    return new SRandMemberCommand<TData>(...args).exec(this.client)
-  }
+  srandmember = <TData>(...args: CommandArgs<typeof SRandMemberCommand>) =>
+    new SRandMemberCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/srem
    */
-  public srem<TData>(key: string, ...members: NonEmptyArray<TData>) {
-    return new SRemCommand<TData>(key, ...members).exec(this.client)
-  }
+  srem = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    new SRemCommand<TData>(key, ...members).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sscan
    */
-  public sscan(...args: CommandArgs<typeof SScanCommand>) {
-    return new SScanCommand(...args).exec(this.client)
-  }
+  sscan = (...args: CommandArgs<typeof SScanCommand>) => new SScanCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/strlen
    */
-  public strlen(...args: CommandArgs<typeof StrLenCommand>) {
-    return new StrLenCommand(...args).exec(this.client)
-  }
+  strlen = (...args: CommandArgs<typeof StrLenCommand>) =>
+    new StrLenCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/sunion
    */
-  public sunion(...args: CommandArgs<typeof SUnionCommand>) {
-    return new SUnionCommand(...args).exec(this.client)
-  }
+  sunion = (...args: CommandArgs<typeof SUnionCommand>) =>
+    new SUnionCommand(...args).exec(this.client)
+
   /**
    * @see https://redis.io/commands/sunionstore
    */
-  public sunionstore(...args: CommandArgs<typeof SUnionStoreCommand>) {
-    return new SUnionStoreCommand(...args).exec(this.client)
-  }
+  sunionstore = (...args: CommandArgs<typeof SUnionStoreCommand>) =>
+    new SUnionStoreCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/time
    */
-  public time() {
-    return new TimeCommand().exec(this.client)
-  }
+  time = () => new TimeCommand().exec(this.client)
 
   /**
    * @see https://redis.io/commands/touch
    */
-  public touch(...args: CommandArgs<typeof TouchCommand>) {
-    return new TouchCommand(...args).exec(this.client)
-  }
+  touch = (...args: CommandArgs<typeof TouchCommand>) => new TouchCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/ttl
    */
-  public ttl(...args: CommandArgs<typeof TtlCommand>) {
-    return new TtlCommand(...args).exec(this.client)
-  }
+  ttl = (...args: CommandArgs<typeof TtlCommand>) => new TtlCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/type
    */
-  public type(...args: CommandArgs<typeof TypeCommand>) {
-    return new TypeCommand(...args).exec(this.client)
-  }
+  type = (...args: CommandArgs<typeof TypeCommand>) => new TypeCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/unlink
    */
-  public unlink(...args: CommandArgs<typeof UnlinkCommand>) {
-    return new UnlinkCommand(...args).exec(this.client)
-  }
+  unlink = (...args: CommandArgs<typeof UnlinkCommand>) =>
+    new UnlinkCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zadd
    */
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public zadd<TData>(
-    key: string,
-    scoreMember: ScoreMember<TData>,
-    ...scoreMemberPairs: ScoreMember<TData>[]
-  ): Promise<number | null>
-  // eslint-disable-next-line no-dupe-class-members,@typescript-eslint/no-unused-vars
-  public zadd<TData>(
-    key: string,
-    opts: ZAddCommandOptions | ZAddCommandOptionsWithIncr,
-    ...scoreMemberPairs: [ScoreMember<TData>, ...ScoreMember<TData>[]]
-  ): Promise<number | null>
-  // eslint-disable-next-line no-dupe-class-members
-  public zadd<TData>(
-    key: string,
-    arg1: ScoreMember<TData> | ZAddCommandOptions | ZAddCommandOptionsWithIncr,
-    ...arg2: ScoreMember<TData>[]
-  ) {
-    if ("score" in arg1) {
-      return new ZAddCommand<TData>(key, arg1 as ScoreMember<TData>, ...arg2).exec(this.client)
+  zadd = <TData>(
+    ...args:
+      | [key: string, scoreMember: ScoreMember<TData>, ...scoreMemberPairs: ScoreMember<TData>[]]
+      | [
+          key: string,
+          opts: ZAddCommandOptions | ZAddCommandOptionsWithIncr,
+          ...scoreMemberPairs: [ScoreMember<TData>, ...ScoreMember<TData>[]]
+        ]
+  ) => {
+    if ("score" in args[1]) {
+      return new ZAddCommand<TData>(
+        args[0],
+        args[1] as ScoreMember<TData>,
+        ...(args.slice(2) as any),
+      ).exec(this.client)
     }
-    return new ZAddCommand<TData>(key, arg1 as any, ...arg2).exec(this.client)
-  }
 
+    return new ZAddCommand<TData>(args[0], args[1] as any, ...(args.slice(2) as any)).exec(
+      this.client,
+    )
+  }
   /**
    * @see https://redis.io/commands/zcard
    */
-  public zcard(...args: CommandArgs<typeof ZCardCommand>) {
-    return new ZCardCommand(...args).exec(this.client)
-  }
+  zcard = (...args: CommandArgs<typeof ZCardCommand>) => new ZCardCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zcount
    */
-  public zcount(...args: CommandArgs<typeof ZCountCommand>) {
-    return new ZCountCommand(...args).exec(this.client)
-  }
+  zcount = (...args: CommandArgs<typeof ZCountCommand>) =>
+    new ZCountCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zincrby
    */
-  public zincrby<TData>(key: string, increment: number, member: TData) {
-    return new ZIncrByComand<TData>(key, increment, member).exec(this.client)
-  }
+  zincrby = <TData>(key: string, increment: number, member: TData) =>
+    new ZIncrByComand<TData>(key, increment, member).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zinterstore
    */
-  public zinterstore(...args: CommandArgs<typeof ZInterStoreCommand>) {
-    return new ZInterStoreCommand(...args).exec(this.client)
-  }
+  zinterstore = (...args: CommandArgs<typeof ZInterStoreCommand>) =>
+    new ZInterStoreCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zlexcount
    */
-  public zlexcount(...args: CommandArgs<typeof ZLexCountCommand>) {
-    return new ZLexCountCommand(...args).exec(this.client)
-  }
+  zlexcount = (...args: CommandArgs<typeof ZLexCountCommand>) =>
+    new ZLexCountCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zpopmax
    */
-  public zpopmax<TData>(...args: CommandArgs<typeof ZPopMaxCommand>) {
-    return new ZPopMaxCommand<TData>(...args).exec(this.client)
-  }
+  zpopmax = <TData>(...args: CommandArgs<typeof ZPopMaxCommand>) =>
+    new ZPopMaxCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zpopmin
    */
-  public zpopmin<TData>(...args: CommandArgs<typeof ZPopMinCommand>) {
-    return new ZPopMinCommand<TData>(...args).exec(this.client)
-  }
+  zpopmin = <TData>(...args: CommandArgs<typeof ZPopMinCommand>) =>
+    new ZPopMinCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zrange
    */
-  public zrange<TData extends unknown[]>(...args: CommandArgs<typeof ZRangeCommand>) {
-    return new ZRangeCommand<TData>(...args).exec(this.client)
-  }
+  zrange = <TData extends unknown[]>(...args: CommandArgs<typeof ZRangeCommand>) =>
+    new ZRangeCommand<TData>(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zrank
    */
-  public zrank<TData>(key: string, member: TData) {
-    return new ZRankCommand<TData>(key, member).exec(this.client)
-  }
+  zrank = <TData>(key: string, member: TData) =>
+    new ZRankCommand<TData>(key, member).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zrem
    */
-  public zrem<TData>(key: string, ...members: NonEmptyArray<TData>) {
-    return new ZRemCommand<TData>(key, ...members).exec(this.client)
-  }
+  zrem = <TData>(key: string, ...members: NonEmptyArray<TData>) =>
+    new ZRemCommand<TData>(key, ...members).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zremrangebylex
    */
-  public zremrangebylex(...args: CommandArgs<typeof ZRemRangeByLexCommand>) {
-    return new ZRemRangeByLexCommand(...args).exec(this.client)
-  }
+  zremrangebylex = (...args: CommandArgs<typeof ZRemRangeByLexCommand>) =>
+    new ZRemRangeByLexCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zremrangebyrank
    */
-  public zremrangebyrank(...args: CommandArgs<typeof ZRemRangeByRankCommand>) {
-    return new ZRemRangeByRankCommand(...args).exec(this.client)
-  }
+  zremrangebyrank = (...args: CommandArgs<typeof ZRemRangeByRankCommand>) =>
+    new ZRemRangeByRankCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zremrangebyscore
    */
-  public zremrangebyscore(...args: CommandArgs<typeof ZRemRangeByScoreCommand>) {
-    return new ZRemRangeByScoreCommand(...args).exec(this.client)
-  }
+  zremrangebyscore = (...args: CommandArgs<typeof ZRemRangeByScoreCommand>) =>
+    new ZRemRangeByScoreCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zrevrank
    */
-  public zrevrank<TData>(key: string, member: TData) {
-    return new ZRevRankCommand<TData>(key, member).exec(this.client)
-  }
+  zrevrank = <TData>(key: string, member: TData) =>
+    new ZRevRankCommand<TData>(key, member).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zscan
    */
-  public zscan(...args: CommandArgs<typeof ZScanCommand>) {
-    return new ZScanCommand(...args).exec(this.client)
-  }
+  zscan = (...args: CommandArgs<typeof ZScanCommand>) => new ZScanCommand(...args).exec(this.client)
 
   /**
    * @see https://redis.io/commands/zscore
    */
-  public zscore<TData>(key: string, member: TData) {
-    return new ZScoreCommand<TData>(key, member).exec(this.client)
-  }
+  zscore = <TData>(key: string, member: TData) =>
+    new ZScoreCommand<TData>(key, member).exec(this.client)
+
   /**
    * @see https://redis.io/commands/zunionstore
    */
-  public zunionstore(...args: CommandArgs<typeof ZUnionStoreCommand>) {
-    return new ZUnionStoreCommand(...args).exec(this.client)
-  }
+  zunionstore = (...args: CommandArgs<typeof ZUnionStoreCommand>) =>
+    new ZUnionStoreCommand(...args).exec(this.client)
 }


### PR DESCRIPTION
This allows you to more or less use a similar API from the last version:
```ts
import { Redis } from "@upstash/redis"
const { get, set } = new Redis({/* TODO: auth */})
```
