### PR TITLE
feat: add "byScore" option to ZRANGE command

### DIFF
--- a/pkg/commands/zrange.test.ts
+++ b/pkg/commands/zrange.test.ts
@@ -23,7 +23,7 @@ describe("without options", () => {
       { score: score2, member: member2 },
     ).exec(client)
 
-    const res = await new ZRangeCommand(key, "(a", "(b", { byLex: true }).exec(client)
+    const res = await new ZRangeCommand(key, 1, 3).exec(client)
     expect(res).toHaveLength(1)
     expect(res![0]).toEqual(member2)
   })

--- a/pkg/commands/zrange.test.ts
+++ b/pkg/commands/zrange.test.ts
@@ -50,3 +50,36 @@ describe("withscores", () => {
     expect(res![1]).toEqual(score2)
   })
 })
+
+describe("byscore", () => {
+  it("returns the set", async () => {
+    const key = newKey()
+    const score1 = 1
+    const member1 = randomUUID()
+
+    const score2 = 2
+    const member2 = randomUUID()
+
+    const score3 = 3
+    const member3 = randomUUID()
+
+    await new ZAddCommand(
+      key,
+      { score: score1, member: member1 },
+      { score: score2, member: member2 },
+      { score: score3, member: member3 },
+    ).exec(client)
+
+    const res = await new ZRangeCommand(key, score1, score2, { byScore: true }).exec(client)
+
+    expect(res).toHaveLength(2)
+    expect(res![0]).toEqual(member1)
+    expect(res![1]).toEqual(member2)
+
+    const res2 = await new ZRangeCommand(key, score1, score3, { byScore: true }).exec(client)
+    expect(res2).toHaveLength(3)
+    expect(res2![0]).toEqual(member1)
+    expect(res2![1]).toEqual(member2)
+    expect(res2![2]).toEqual(member3)
+  })
+})

--- a/pkg/commands/zrange.test.ts
+++ b/pkg/commands/zrange.test.ts
@@ -81,6 +81,9 @@ describe("byscore", () => {
     expect(res2![0]).toEqual(member1)
     expect(res2![1]).toEqual(member2)
     expect(res2![2]).toEqual(member3)
+
+    const res3 = await new ZRangeCommand(key, "-inf", "+inf", { byScore: true }).exec(client)
+    expect(res3).toEqual(res2)
   })
 })
 
@@ -97,15 +100,18 @@ describe("bylex", () => {
 
     // everything in between a and c, excluding "a" and including "c"
     const res = await new ZRangeCommand(key, "(a", "[c", { byLex: true }).exec(client)
-
     expect(res).toHaveLength(2)
     expect(res![0]).toEqual("b")
     expect(res![1]).toEqual("c")
 
+    //everything after "a", excluding a
+    const res2 = await new ZRangeCommand(key, "(a", "+", { byLex: true }).exec(client)
+    expect(res2).toEqual(res)
+
     // everything in between a and "bb", including "a" and excluding "bb"
-    const res2 = await new ZRangeCommand(key, "[a", "(bb", { byLex: true }).exec(client)
-    expect(res2).toHaveLength(2)
-    expect(res2![0]).toEqual("a")
-    expect(res2![1]).toEqual("b")
+    const res3 = await new ZRangeCommand(key, "[a", "(bb", { byLex: true }).exec(client)
+    expect(res3).toHaveLength(2)
+    expect(res3![0]).toEqual("a")
+    expect(res3![1]).toEqual("b")
   })
 })

--- a/pkg/commands/zrange.test.ts
+++ b/pkg/commands/zrange.test.ts
@@ -23,7 +23,7 @@ describe("without options", () => {
       { score: score2, member: member2 },
     ).exec(client)
 
-    const res = await new ZRangeCommand(key, 1, 3).exec(client)
+    const res = await new ZRangeCommand(key, "(a", "(b", { byLex: true }).exec(client)
     expect(res).toHaveLength(1)
     expect(res![0]).toEqual(member2)
   })
@@ -81,5 +81,31 @@ describe("byscore", () => {
     expect(res2![0]).toEqual(member1)
     expect(res2![1]).toEqual(member2)
     expect(res2![2]).toEqual(member3)
+  })
+})
+
+describe("bylex", () => {
+  it("returns the set", async () => {
+    const key = newKey()
+
+    await new ZAddCommand(
+      key,
+      { score: 0, member: "a" },
+      { score: 0, member: "b" },
+      { score: 0, member: "c" },
+    ).exec(client)
+
+    // everything in between a and c, excluding "a" and including "c"
+    const res = await new ZRangeCommand(key, "(a", "[c", { byLex: true }).exec(client)
+
+    expect(res).toHaveLength(2)
+    expect(res![0]).toEqual("b")
+    expect(res![1]).toEqual("c")
+
+    // everything in between a and "bb", including "a" and excluding "bb"
+    const res2 = await new ZRangeCommand(key, "[a", "(bb", { byLex: true }).exec(client)
+    expect(res2).toHaveLength(2)
+    expect(res2![0]).toEqual("a")
+    expect(res2![1]).toEqual("b")
   })
 })

--- a/pkg/commands/zrange.ts
+++ b/pkg/commands/zrange.ts
@@ -1,6 +1,8 @@
 import { Command } from "./command"
+
 export type ZRangeCommandOptions = {
   withScores?: boolean
+  byScore?: boolean
 }
 
 /**
@@ -14,6 +16,11 @@ export class ZRangeCommand<TData extends unknown[]> extends Command<TData, strin
     opts?: ZRangeCommandOptions,
   ) {
     const command: unknown[] = ["zrange", key, min, max]
+
+    // Either byScore or byLex is allowed
+    if (opts?.byScore) {
+      command.push("byscore")
+    }
     if (opts?.withScores) {
       command.push("withscores")
     }

--- a/pkg/commands/zrange.ts
+++ b/pkg/commands/zrange.ts
@@ -15,14 +15,20 @@ export class ZRangeCommand<TData extends unknown[]> extends Command<TData, strin
   constructor(key: string, min: number, max: number, opts?: ZRangeCommandOptions)
   constructor(
     key: string,
-    min: `(${string}` | `[${string}`,
-    max: `(${string}` | `[${string}`,
+    min: `(${string}` | `[${string}` | "-" | "+",
+    max: `(${string}` | `[${string}` | "-" | "+",
     opts: { byLex: true } & ZRangeCommandOptions,
   )
   constructor(
     key: string,
-    min: number | `(${number}` | `(${string}` | `[${string}`,
-    max: number | `(${number}` | `(${string}` | `[${string}`,
+    min: number | `(${number}` | "-inf" | "+inf",
+    max: number | `(${number}` | "-inf" | "+inf",
+    opts: { byScore: true } & ZRangeCommandOptions,
+  )
+  constructor(
+    key: string,
+    min: number | string,
+    max: number | string,
     opts?: ZRangeCommandOptions,
   ) {
     const command: unknown[] = ["zrange", key, min, max]

--- a/pkg/commands/zrange.ts
+++ b/pkg/commands/zrange.ts
@@ -2,17 +2,27 @@ import { Command } from "./command"
 
 export type ZRangeCommandOptions = {
   withScores?: boolean
-  byScore?: boolean
-}
+} & (
+  | { byScore: true; byLex?: never }
+  | { byScore?: never; byLex: true }
+  | { byScore?: never; byLex?: never }
+)
 
 /**
  * @see https://redis.io/commands/zrange
  */
 export class ZRangeCommand<TData extends unknown[]> extends Command<TData, string[]> {
+  constructor(key: string, min: number, max: number, opts?: ZRangeCommandOptions)
   constructor(
     key: string,
-    min: number | `(${number}`,
-    max: number | `(${number}`,
+    min: `(${string}` | `[${string}`,
+    max: `(${string}` | `[${string}`,
+    opts: { byLex: true } & ZRangeCommandOptions,
+  )
+  constructor(
+    key: string,
+    min: number | `(${number}` | `(${string}` | `[${string}`,
+    max: number | `(${number}` | `(${string}` | `[${string}`,
     opts?: ZRangeCommandOptions,
   ) {
     const command: unknown[] = ["zrange", key, min, max]
@@ -20,6 +30,9 @@ export class ZRangeCommand<TData extends unknown[]> extends Command<TData, strin
     // Either byScore or byLex is allowed
     if (opts?.byScore) {
       command.push("byscore")
+    }
+    if (opts?.byLex) {
+      command.push("bylex")
     }
     if (opts?.withScores) {
       command.push("withscores")

--- a/pkg/commands/zrange.ts
+++ b/pkg/commands/zrange.ts
@@ -17,13 +17,13 @@ export class ZRangeCommand<TData extends unknown[]> extends Command<TData, strin
     key: string,
     min: `(${string}` | `[${string}` | "-" | "+",
     max: `(${string}` | `[${string}` | "-" | "+",
-    opts: { byLex: true } & ZRangeCommandOptions,
+    opts?: { byLex: true } & ZRangeCommandOptions,
   )
   constructor(
     key: string,
     min: number | `(${number}` | "-inf" | "+inf",
     max: number | `(${number}` | "-inf" | "+inf",
-    opts: { byScore: true } & ZRangeCommandOptions,
+    opts?: { byScore: true } & ZRangeCommandOptions,
   )
   constructor(
     key: string,


### PR DESCRIPTION
## About

This PR adds an option "byScore" to the ZRANGE command (see [documentation](https://redis.io/commands/zrange/)). 

This feature allows ZRANGE queries for all entries whose scores are in a certain range (between `min` and `max`).

## Usage:

```typescript

// return all entries of the set "key" whose scores are between 0 and 10
await redis.zrange("key", 0, 10, { byScore: true });

```