### PR TITLE
ci: add build time to release tag

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -972,7 +972,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::v0.0.0-ci.${GITHUB_SHA::8}-$(shell date -u '+%Y%m%d')"
+        run: echo "::set-output name=version::v0.0.0-ci.${GITHUB_SHA::8}-$(date '+%Y%m%d')"
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -972,7 +972,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::v0.0.0-ci.${GITHUB_SHA::8}"
+        run: echo "::set-output name=version::v0.0.0-ci.${GITHUB_SHA::8}-$(shell date -u '+%Y%m%d')"
 
       - name: Setup Node
         uses: actions/setup-node@v2


### PR DESCRIPTION
The daily tests were failing because it could not create the same tag
twice.
