### PR TITLE
fix: set `cache: 'no-store'`

### DIFF
--- a/pkg/http.ts
+++ b/pkg/http.ts
@@ -164,6 +164,7 @@ export class HttpClient implements Requester {
     req: UpstashRequest,
   ): Promise<UpstashResponse<TResult>> {
     const requestOptions: RequestInit & { backend?: string; agent?: any } = {
+      cache: "no-store",
       method: "POST",
       headers: this.headers,
       body: JSON.stringify(req.body),


### PR DESCRIPTION
In Next.js v13, `fetch` responses are cached, so when a similar request is sent multiple times, the first response is always returned, which is not the intended behavior. Add `cache: 'no-store'` to the `fetch` options to disable unintended caching. Since `cache: 'no-store'` is a standard option, it may work on other platforms as well.