### PR TITLE
avoid accessing process.version in edge runtime

### DIFF
--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -130,7 +130,7 @@ export class Redis extends core.Redis {
     });
 
     this.addTelemetry({
-      runtime: `node@${process.version}`,
+      runtime: typeof EdgeRuntime === "string" ? `edge-light` : `node@${process.version}`,
       platform: process.env.VERCEL
         ? "vercel"
         : process.env.AWS_REGION


### PR DESCRIPTION
Avoids this error when the package is used in Edge Runtime by [addressing the runtime](https://edge-runtime.vercel.app/features/available-apis#addressing-the-runtime) and thus preventing access of process.version in edge runtime.

![image](https://user-images.githubusercontent.com/1765075/236111994-f41296b0-19a6-48ca-b8c4-25e3980a65c1.png)
