### PR TITLE
Fix missing assertions and paths

### DIFF
--- a/pkg/commands/hscan.test.ts
+++ b/pkg/commands/hscan.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { keygen, newHttpClient } from "../test-utils";
 
 import { HScanCommand } from "./hscan";
@@ -7,38 +7,38 @@ const client = newHttpClient();
 
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
-test("without options", () => {
+describe("without options", () => {
   test("returns cursor and members", async () => {
     const key = newKey();
     await new HSetCommand([key, { field: "value" }]).exec(client);
     const res = await new HScanCommand([key, 0]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
-test("with match", () => {
+describe("with match", () => {
   test("returns cursor and members", async () => {
     const key = newKey();
     await new HSetCommand([key, { field: "value" }]).exec(client);
     const res = await new HScanCommand([key, 0, { match: "field" }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
-test("with count", () => {
+describe("with count", () => {
   test("returns cursor and members", async () => {
     const key = newKey();
     await new HSetCommand([key, { field: "value" }]).exec(client);
     const res = await new HScanCommand([key, 0, { count: 1 }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });

--- a/pkg/commands/json_arrappend.test.ts
+++ b/pkg/commands/json_arrappend.test.ts
@@ -25,7 +25,7 @@ test("Add a new color to a list of product colors", async () => {
       colors: ["black", "silver"],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonArrAppendCommand([key, "$.colors", '"blue"']).exec(client);
   expect(res2).toEqual([3]);
   const res3 = await new JsonGetCommand([key]).exec(client);

--- a/pkg/commands/json_arrindex.test.ts
+++ b/pkg/commands/json_arrindex.test.ts
@@ -27,7 +27,7 @@ test("Find the specific place of a color in a list of product colors", async () 
       colors: ["black", "silver"],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonArrAppendCommand([key, "$.colors", '"blue"']).exec(client);
   expect(res2).toEqual([3]);
   const res3 = await new JsonGetCommand([key]).exec(client);
@@ -40,15 +40,15 @@ test("Find the specific place of a color in a list of product colors", async () 
     colors: ["black", "silver", "blue"],
   });
   const res4 = await new JsonGetCommand([key, "$.colors[*]"]).exec(client);
-  expect(res4, ["black", "silver", "blue"]);
+  expect(res4).toEqual(["black", "silver", "blue"]);
 
   const res5 = await new JsonArrInsertCommand([key, "$.colors", 2, '"yellow"', '"gold"']).exec(
-    client,
+    client
   );
-  expect(res5, [5]);
+  expect(res5).toEqual([5]);
   const res6 = await new JsonGetCommand([key, "$.colors"]).exec(client);
-  expect(res6, [["black", "silver", "yellow", "gold", "blue"]]);
+  expect(res6).toEqual([["black", "silver", "yellow", "gold", "blue"]]);
 
   const res7 = await new JsonArrIndexCommand([key, "$..colors", '"silver"']).exec(client);
-  expect(res7, [1]);
+  expect(res7).toEqual([1]);
 });

--- a/pkg/commands/json_arrinsert.test.ts
+++ b/pkg/commands/json_arrinsert.test.ts
@@ -26,7 +26,7 @@ test("Add new colors to a specific place in a list of product colors", async () 
       colors: ["black", "silver"],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonArrAppendCommand([key, "$.colors", '"blue"']).exec(client);
   expect(res2).toEqual([3]);
   const res3 = await new JsonGetCommand([key]).exec(client);
@@ -39,11 +39,11 @@ test("Add new colors to a specific place in a list of product colors", async () 
     colors: ["black", "silver", "blue"],
   });
   const res4 = await new JsonGetCommand([key, "$.colors"]).exec(client);
-  expect(res4, [["black", "silver", "blue"]]);
+  expect(res4).toEqual([["black", "silver", "blue"]]);
   const res5 = await new JsonArrInsertCommand([key, "$.colors", 2, '"yellow"', '"gold"']).exec(
-    client,
+    client
   );
-  expect(res5, [5]);
+  expect(res5).toEqual([5]);
   const res6 = await new JsonGetCommand([key, "$.colors"]).exec(client);
-  expect(res6, [["black", "silver", "yellow", "gold", "blue"]]);
+  expect(res6).toEqual([["black", "silver", "yellow", "gold", "blue"]]);
 });

--- a/pkg/commands/json_arrlen.test.ts
+++ b/pkg/commands/json_arrlen.test.ts
@@ -25,7 +25,7 @@ test("Get lengths of JSON arrays in a document", async () => {
       max_level: [80, 100, 120],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonArrLenCommand([key, "$.max_level"]).exec(client);
   expect(res2).toEqual([3]);
 });

--- a/pkg/commands/json_arrpop.test.ts
+++ b/pkg/commands/json_arrpop.test.ts
@@ -20,7 +20,7 @@ test("Pop a value from an index and insert a new value", async () => {
       max_level: [80, 90, 100, 120],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
 
   const res2 = await new JsonArrPopCommand([key, "$.max_level", 0]).exec(client);
   expect(res2).toEqual([80]);

--- a/pkg/commands/json_arrtrim.test.ts
+++ b/pkg/commands/json_arrtrim.test.ts
@@ -21,11 +21,11 @@ test("Trim an array to a specific set of values", async () => {
       a: [1],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonArrAppendCommand([key, "$.a", 2]).exec(client);
-  expect(res2.sort(), [2]);
+  expect(res2.sort()).toEqual([2]);
   const res3 = await new JsonArrTrimCommand([key, "$.a", 1, 1]).exec(client);
   expect(res3).toEqual([1]);
   const res4 = await new JsonGetCommand([key, "$.a"]).exec(client);
-  expect(res4, [[2]]);
+  expect(res4).toEqual([[2]]);
 });

--- a/pkg/commands/json_clear.test.ts
+++ b/pkg/commands/json_clear.test.ts
@@ -18,7 +18,7 @@ test("Clear container values and set numeric values to 0", async () => {
     "$",
     '{"obj":{"a":1, "b":2}, "arr":[1,2,3], "str": "foo", "bool": true, "int": 42, "float": 3.14}',
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonClearCommand([key, "$.*"]).exec(client);
   expect(res2).toEqual(4);
   const res3 = await new JsonGetCommand([key, "$"]).exec(client);

--- a/pkg/commands/json_del.test.ts
+++ b/pkg/commands/json_del.test.ts
@@ -21,7 +21,7 @@ test("Delete a value", async () => {
       nested: { a: 2, b: 3 },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonDelCommand([key, "$..a"]).exec(client);
   expect(res2).toEqual(2);
   const res3 = await new JsonGetCommand([key, "$"]).exec(client);

--- a/pkg/commands/json_forget.test.ts
+++ b/pkg/commands/json_forget.test.ts
@@ -21,7 +21,7 @@ test("Delete a value", async () => {
       nested: { a: 2, b: 3 },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonForgetCommand([key, "$..a"]).exec(client);
   expect(res2).toEqual(2);
   const res3 = await new JsonGetCommand([key, "$"]).exec(client);

--- a/pkg/commands/json_get.test.ts
+++ b/pkg/commands/json_get.test.ts
@@ -20,7 +20,7 @@ test("Return the value at path in JSON serialized form", async () => {
       nested: { a: 4, b: null },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonGetCommand([key, "$..b"]).exec(client);
   expect(res2).toEqual([null, 3]);
   const res3 = await new JsonGetCommand([key, "$..a", "$..b"]).exec(client);

--- a/pkg/commands/json_mget.test.ts
+++ b/pkg/commands/json_mget.test.ts
@@ -22,7 +22,7 @@ test("Return the values at path from multiple key arguments", async () => {
       c: null,
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
 
   const res2 = await new JsonSetCommand([
     key2,

--- a/pkg/commands/json_nummultby.test.ts
+++ b/pkg/commands/json_nummultby.test.ts
@@ -20,9 +20,9 @@ test("return the length", async () => {
       b: [{ a: 2 }, { a: 5 }, { a: "c" }],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonNumMultByCommand([key, "$.a", 2]).exec(client);
-  expect(res2.sort(), [null]);
+  expect(res2.sort()).toEqual([null]);
   const res3 = await new JsonNumMultByCommand([key, "$..a", 2]).exec(client);
-  expect(res3.sort(), [10, 4, null, null]);
+  expect(res3.sort()).toEqual([10, 4, null, null]);
 });

--- a/pkg/commands/json_objlen.test.ts
+++ b/pkg/commands/json_objlen.test.ts
@@ -20,7 +20,7 @@ test("return the length", async () => {
       nested: { a: { b: 2, c: 1 } },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonObjLenCommand([key, "$..a"]).exec(client);
   expect(res2).toEqual([2, null]);
 });

--- a/pkg/commands/json_resp.test.ts
+++ b/pkg/commands/json_resp.test.ts
@@ -25,7 +25,7 @@ test("Return an array of RESP details about a document", async () => {
       max_level: [80, 100, 120],
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonRespCommand([key]).exec(client);
-  expect(res2.length, 15);
+  expect(res2.length).toBe(15);
 });

--- a/pkg/commands/json_strappend.test.ts
+++ b/pkg/commands/json_strappend.test.ts
@@ -22,9 +22,9 @@ test("Add 'baz' to existing string", async () => {
       nested2: { a: 31 },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonStrAppendCommand([key, "$..a", '"baz"']).exec(client);
-  expect(res2.sort(), [6, 8, null]);
+  expect(res2.sort()).toEqual([6, 8, null]);
   const res3 = await new JsonGetCommand([key]).exec(client);
   expect(res3).toEqual({
     a: "foobaz",

--- a/pkg/commands/json_strlen.test.ts
+++ b/pkg/commands/json_strlen.test.ts
@@ -21,7 +21,7 @@ test("return the length", async () => {
       nested2: { a: 31 },
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonStrLenCommand([key, "$..a"]).exec(client);
-  expect(res2.sort(), [3, 5, null]);
+  expect(res2.sort()).toEqual([3, 5, null]);
 });

--- a/pkg/commands/json_toggle.test.ts
+++ b/pkg/commands/json_toggle.test.ts
@@ -14,13 +14,13 @@ afterAll(cleanup);
 test("Toogle a Boolean value stored at path", async () => {
   const key = newKey();
   const res1 = await new JsonSetCommand([key, "$", { bool: true }]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonToggleCommand([key, "$.bool"]).exec(client);
   expect(res2).toEqual([0]);
   const res3 = await new JsonGetCommand([key, "$"]).exec(client);
   expect(res3).toEqual([{ bool: false }]);
   const res4 = await new JsonToggleCommand([key, "$.bool"]).exec(client);
-  expect(res4, [1]);
+  expect(res4).toEqual([1]);
   const res5 = await new JsonGetCommand([key, "$"]).exec(client);
-  expect(res5, [{ bool: true }]);
+  expect(res5).toEqual([{ bool: true }]);
 });

--- a/pkg/commands/json_type.test.ts
+++ b/pkg/commands/json_type.test.ts
@@ -21,9 +21,9 @@ test("return the length", async () => {
       foo: "bar",
     },
   ]).exec(client);
-  expect(res1, "OK");
+  expect(res1).toBe("OK");
   const res2 = await new JsonTypeCommand([key, "$..foo"]).exec(client);
-  expect(res2.sort(), ["string"]);
+  expect(res2.sort()).toEqual(["string"]);
   const res3 = await new JsonTypeCommand([key, "$..a"]).exec(client);
-  expect(res3.sort(), ["boolean", "integer"]);
+  expect(res3.sort()).toEqual(["boolean", "integer"]);
 });

--- a/pkg/commands/linsert.test.ts
+++ b/pkg/commands/linsert.test.ts
@@ -20,5 +20,5 @@ test("adds the element", async () => {
   expect(res).toEqual(2);
 
   const list = await new LRangeCommand([key, 0, -1]).exec(client);
-  expect(list, [value2, value1]);
+  expect(list).toEqual([value2, value1]);
 });

--- a/pkg/commands/lmove.test.ts
+++ b/pkg/commands/lmove.test.ts
@@ -22,10 +22,10 @@ test("moves the entry from left to left", async () => {
   expect(res).toEqual(value);
 
   const elementInSource = await new LPopCommand([source]).exec(client);
-  expect(elementInSource, null);
+  expect(elementInSource).toEqual(null);
 
   const elementInDestination = await new LPopCommand([destination]).exec(client);
-  expect(elementInDestination, value);
+  expect(elementInDestination).toBe(value);
 });
 
 test("moves the entry from left to right", async () => {
@@ -39,8 +39,8 @@ test("moves the entry from left to right", async () => {
   expect(res).toEqual(values.at(-1));
 
   const elementsInSource = await new LLenCommand([source]).exec(client);
-  expect(elementsInSource, values.length - 1);
+  expect(elementsInSource).toEqual(values.length - 1);
 
   const elementInDestination = await new LPopCommand([destination]).exec(client);
-  expect(elementInDestination, values.at(-1));
+  expect(elementInDestination).toEqual(values.at(-1));
 });

--- a/pkg/commands/lpos.test.ts
+++ b/pkg/commands/lpos.test.ts
@@ -25,7 +25,7 @@ test("with rank", () => {
     const key = newKey();
     await new RPushCommand([key, "a", "b", "c", 1, 2, 3, "c", "c"]).exec(client);
     const cmd = new LPosCommand([key, "c", { rank: 2 }]);
-    expect(cmd.command, ["lpos", key, "c", "rank", 2]);
+    expect(cmd.command).toEqual(["lpos", key, "c", "rank", 2]);
     const res = await cmd.exec(client);
     expect(res).toEqual(6);
   });

--- a/pkg/commands/lrange.test.ts
+++ b/pkg/commands/lrange.test.ts
@@ -15,7 +15,7 @@ test("returns the correct range", async () => {
   const value3 = randomID();
   await new RPushCommand([key, value1, value2, value3]).exec(client);
   const res = await new LRangeCommand([key, 1, 2]).exec(client);
-  expect(res!.length, 2);
-  expect(res![0], value2);
-  expect(res![1], value3);
+  expect(res!.length).toBe(2);
+  expect(res![0]).toBe(value2);
+  expect(res![1]).toBe(value3);
 });

--- a/pkg/commands/ping.test.ts
+++ b/pkg/commands/ping.test.ts
@@ -1,16 +1,17 @@
+import { describe, test, expect } from "bun:test";
 import { newHttpClient, randomID } from "../test-utils";
 import { PingCommand } from "./ping";
 
 const client = newHttpClient();
 
-test("with message", () => {
+describe("with message", () => {
   test("returns the message", async () => {
     const message = randomID();
     const res = await new PingCommand([message]).exec(client);
     expect(res).toEqual(message);
   });
 });
-test("without message", () => {
+describe("without message", () => {
   test("returns pong", async () => {
     const res = await new PingCommand([]).exec(client);
     expect(res).toEqual("PONG");

--- a/pkg/commands/pttl.test.ts
+++ b/pkg/commands/pttl.test.ts
@@ -14,5 +14,5 @@ test("returns the ttl on a key", async () => {
   const ttl = 60;
   await new SetExCommand([key, ttl, "value"]).exec(client);
   const res = await new PTtlCommand([key]).exec(client);
-  expect(res <= ttl * 1000, true);
+  expect(res <= ttl * 1000).toBe(true);
 });

--- a/pkg/commands/publish.test.ts
+++ b/pkg/commands/publish.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "bun:test";
 import { newHttpClient } from "../test-utils";
 
 import { PublishCommand } from "./publish";
@@ -7,5 +8,5 @@ const client = newHttpClient();
 test("returns the number of clients that received the message", async () => {
   const res = await new PublishCommand(["channel", "hello"]).exec(client);
 
-  expect(typeof res, "number");
+  expect(typeof res).toBe("number");
 });

--- a/pkg/commands/randomkey.test.ts
+++ b/pkg/commands/randomkey.test.ts
@@ -12,5 +12,5 @@ test("returns a random key", async () => {
   const key = newKey();
   await new SetCommand([key, randomID()]).exec(client);
   const res = await new RandomKeyCommand().exec(client);
-  expect(typeof res, "string");
+  expect(typeof res).toBe("string");
 });

--- a/pkg/commands/script_exists.test.ts
+++ b/pkg/commands/script_exists.test.ts
@@ -1,11 +1,12 @@
+import { describe, expect, test } from "bun:test";
 import { newHttpClient, randomID } from "../test-utils";
 import { ScriptExistsCommand } from "./script_exists";
 import { ScriptLoadCommand } from "./script_load";
 
 const client = newHttpClient();
 
-test("with a single script", () => {
-  test("when the script exists", () => {
+describe("with a single script", () => {
+  describe("when the script exists", () => {
     test("returns 1", async () => {
       const script = `return "${randomID()}"`;
       const hash = await new ScriptLoadCommand([script]).exec(client);
@@ -13,14 +14,15 @@ test("with a single script", () => {
       expect(res).toEqual([1]);
     });
   });
-  test("when the script does not exist", () => {
+  describe("when the script does not exist", () => {
     test("returns 0", async () => {
       const res = await new ScriptExistsCommand(["21"]).exec(client);
       expect(res).toEqual([0]);
     });
   });
 });
-test("with multiple scripts", () => {
+
+describe("with multiple scripts", () => {
   test("returns the found scripts", async () => {
     const script1 = `return "${randomID()}"`;
     const script2 = `return "${randomID()}"`;

--- a/pkg/commands/script_flush.test.ts
+++ b/pkg/commands/script_flush.test.ts
@@ -3,31 +3,32 @@ import { ScriptLoadCommand } from "./script_load";
 
 import { ScriptExistsCommand } from "./script_exists";
 import { ScriptFlushCommand } from "./script_flush";
+import { describe, test, expect } from "bun:test";
 const client = newHttpClient();
 
-test("sync", () => {
+describe("sync", () => {
   test("flushes all scripts", async () => {
     const script = `return "${randomID()}"`;
     const sha1 = await new ScriptLoadCommand([script]).exec(client);
-    expect(await new ScriptExistsCommand([sha1]).exec(client), [1]);
+    expect(await new ScriptExistsCommand([sha1]).exec(client)).toEqual([1]);
 
     const res = await new ScriptFlushCommand([{ sync: true }]).exec(client);
     expect(res).toEqual("OK");
-    expect(await new ScriptExistsCommand([sha1]).exec(client), [0]);
+    expect(await new ScriptExistsCommand([sha1]).exec(client)).toEqual([0]);
   });
 });
 
-test("async", () => {
+describe("async", () => {
   test("flushes all scripts", async () => {
     const script = `return "${randomID()}"`;
     const sha1 = await new ScriptLoadCommand([script]).exec(client);
-    expect(await new ScriptExistsCommand([sha1]).exec(client), [1]);
+    expect(await new ScriptExistsCommand([sha1]).exec(client)).toEqual([1]);
 
     const res = await new ScriptFlushCommand([{ async: true }]).exec(client);
 
     expect(res).toEqual("OK");
 
     await new Promise((res) => setTimeout(res, 5000));
-    expect(await new ScriptExistsCommand([sha1]).exec(client), [0]);
+    expect(await new ScriptExistsCommand([sha1]).exec(client)).toEqual([0]);
   });
 });

--- a/pkg/commands/script_load.test.ts
+++ b/pkg/commands/script_load.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "bun:test";
 import { newHttpClient } from "../test-utils";
 import { ScriptLoadCommand } from "./script_load";
 

--- a/pkg/commands/sinter.test.ts
+++ b/pkg/commands/sinter.test.ts
@@ -16,9 +16,9 @@ test("with single set", () => {
     const value2 = { v: randomID() };
     await new SAddCommand([key, value1, value2]).exec(client);
     const res = await new SInterCommand<{ v: string }>([key]).exec(client);
-    expect(res.length, 2);
-    expect(res.map(({ v }) => v).includes(value1.v), true);
-    expect(res.map(({ v }) => v).includes(value2.v), true);
+    expect(res.length).toBe(2);
+    expect(res.map(({ v }) => v).includes(value1.v)).toBe(true);
+    expect(res.map(({ v }) => v).includes(value2.v)).toBe(true);
   });
 });
 

--- a/pkg/commands/smembers.test.ts
+++ b/pkg/commands/smembers.test.ts
@@ -16,7 +16,7 @@ test("returns all members of the set", async () => {
   await new SAddCommand([key, value1, value2]).exec(client);
   const res = await new SMembersCommand<{ v: string }[]>([key]).exec(client);
 
-  expect(res!.length, 2);
-  expect(res!.map(({ v }) => v).includes(value1.v), true);
-  expect(res!.map(({ v }) => v).includes(value2.v), true);
+  expect(res!.length).toBe(2);
+  expect(res!.map(({ v }) => v).includes(value1.v));
+  expect(res!.map(({ v }) => v).includes(value2.v)).toBe(true);
 });

--- a/pkg/commands/spop.test.ts
+++ b/pkg/commands/spop.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { SAddCommand } from "./sadd";
 import { SPopCommand } from "./spop";
 
@@ -9,7 +9,7 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("without count", () => {
+describe("without count", () => {
   test("returns the first element", async () => {
     const key = newKey();
     const member = randomID();
@@ -19,7 +19,7 @@ test("without count", () => {
   });
 });
 
-test("with count", () => {
+describe("with count", () => {
   test("returns n elements", async () => {
     const key = newKey();
     const member1 = randomID();
@@ -29,8 +29,8 @@ test("with count", () => {
     await new SAddCommand([key, member1, member2, member3, member4]).exec(client);
     const res = await new SPopCommand<string[]>([key, 2]).exec(client);
 
-    expect(res?.length, 2);
-    expect([member1, member2, member3, member4].includes(res![0]), true);
-    expect([member1, member2, member3, member4].includes(res![1]), true);
+    expect(res?.length).toBe(2);
+    expect([member1, member2, member3, member4].includes(res![0])).toBe(true);
+    expect([member1, member2, member3, member4].includes(res![1])).toBe(true);
   });
 });

--- a/pkg/commands/srandmember.test.ts
+++ b/pkg/commands/srandmember.test.ts
@@ -26,6 +26,6 @@ test("with count", () => {
     const member2 = randomID();
     await new SAddCommand([key, member1, member2]).exec(client);
     const res = await new SRandMemberCommand<unknown[]>([key, 2]).exec(client);
-    expect(res?.length, 2);
+    expect(res?.length).toBe(2);
   });
 });

--- a/pkg/commands/sscan.test.ts
+++ b/pkg/commands/sscan.test.ts
@@ -6,6 +6,7 @@ import { SScanCommand } from "./sscan";
 const client = newHttpClient();
 
 const { newKey, cleanup } = keygen();
+
 afterAll(cleanup);
 test("without options", () => {
   test("returns cursor and members", async () => {
@@ -14,9 +15,9 @@ test("without options", () => {
     await new SAddCommand([key, member]).exec(client);
     const res = await new SScanCommand([key, 0]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
@@ -27,9 +28,9 @@ test("with match", () => {
     await new SAddCommand([key, member]).exec(client);
     const res = await new SScanCommand([key, 0, { match: member }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
@@ -40,8 +41,8 @@ test("with count", () => {
     await new SAddCommand([key, member]).exec(client);
     const res = await new SScanCommand([key, 0, { count: 1 }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });

--- a/pkg/commands/sunion.test.ts
+++ b/pkg/commands/sunion.test.ts
@@ -18,5 +18,5 @@ test("returns the union", async () => {
   await new SAddCommand([key1, member1]).exec(client);
   await new SAddCommand([key2, member2]).exec(client);
   const res = await new SUnionCommand([key1, key2]).exec(client);
-  expect(res?.sort(), [member1, member2].sort());
+  expect(res?.sort()).toEqual([member1, member2].sort());
 });

--- a/pkg/commands/time.test.ts
+++ b/pkg/commands/time.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "bun:test";
 import { newHttpClient } from "../test-utils";
 
 import { TimeCommand } from "./time";
@@ -6,6 +7,6 @@ const client = newHttpClient();
 test("returns the time", async () => {
   const res = await new TimeCommand().exec(client);
 
-  expect(typeof res[0], "number");
-  expect(typeof res[1], "number");
+  expect(typeof res[0]).toBe("number");
+  expect(typeof res[1]).toBe("number");
 });

--- a/pkg/commands/xrange.test.ts
+++ b/pkg/commands/xrange.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { XAddCommand } from "./xadd";
 import { XRangeCommand } from "./xrange";
 
@@ -9,7 +9,7 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the set", async () => {
     const key = newKey();
     const field1 = "field1";
@@ -21,15 +21,15 @@ test("without options", () => {
     await new XAddCommand([key, "*", { [field1]: member1, [field2]: member2 }]).exec(client);
 
     const res = await new XRangeCommand([key, "-", "+"]).exec(client);
-    expect(Object.keys(res).length, 1);
-    expect(Object.values(res)[0], {
+    expect(Object.keys(res).length).toBe(1);
+    expect(Object.values(res)[0]).toEqual({
       [field1]: member1,
       [field2]: member2,
     });
   });
 });
 
-test("limit", () => {
+describe("limit", () => {
   test("returns the only the first one", async () => {
     const key = newKey();
     const field1 = "field1";
@@ -42,8 +42,8 @@ test("limit", () => {
     await new XAddCommand([key, "*", { [field2]: member2 }]).exec(client);
 
     const res = await new XRangeCommand([key, "-", "+", 1]).exec(client);
-    expect(Object.keys(res).length, 1);
-    expect(Object.values(res)[0], {
+    expect(Object.keys(res).length).toBe(1);
+    expect(Object.values(res)[0]).toEqual({
       [field1]: member1,
     });
   });
@@ -62,8 +62,8 @@ test("many fields", () => {
       const id = await new XAddCommand([key, "*", fields]).exec(client);
 
       const res = await new XRangeCommand([key, "-", "+"]).exec(client);
-      expect(Object.keys(res).length, i);
-      expect(res[id], fields);
+      expect(Object.keys(res).length).toBe(i);
+      expect(res[id]).toEqual(fields);
     }
   });
 });

--- a/pkg/commands/zadd.test.ts
+++ b/pkg/commands/zadd.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, expect, test, describe } from "bun:test";
 import { ZAddCommand } from "./zadd";
 import { ZScoreCommand } from "./zscore";
 
@@ -9,10 +9,10 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("command format", () => {
-  test("without options", () => {
+describe("command format", () => {
+  describe("without options", () => {
     test("build the correct command", () => {
-      expect(new ZAddCommand(["key", { score: 0, member: "member" }]).command, [
+      expect(new ZAddCommand(["key", { score: 0, member: "member" }]).command).toEqual([
         "zadd",
         "key",
         0,
@@ -20,68 +20,57 @@ test("command format", () => {
       ]);
     });
   });
-  test("with nx", () => {
-    test("build the correct command", () => {
-      expect(new ZAddCommand(["key", { nx: true }, { score: 0, member: "member" }]).command, [
-        "zadd",
-        "key",
-        "nx",
-        0,
-        "member",
-      ]);
-    });
-  });
-  test("with xx", () => {
-    test("build the correct command", () => {
-      expect(new ZAddCommand(["key", { xx: true }, { score: 0, member: "member" }]).command, [
-        "zadd",
-        "key",
-        "xx",
-        0,
-        "member",
-      ]);
-    });
-  });
-  test("with ch", () => {
-    test("build the correct command", () => {
-      expect(new ZAddCommand(["key", { ch: true }, { score: 0, member: "member" }]).command, [
-        "zadd",
-        "key",
-        "ch",
-        0,
-        "member",
-      ]);
-    });
-  });
-  test("with incr", () => {
-    test("build the correct command", () => {
-      expect(new ZAddCommand(["key", { incr: true }, { score: 0, member: "member" }]).command, [
-        "zadd",
-        "key",
-        "incr",
-        0,
-        "member",
-      ]);
-    });
-  });
-  test("with nx and ch", () => {
+
+  describe("with nx", () => {
     test("build the correct command", () => {
       expect(
-        new ZAddCommand(["key", { nx: true, ch: true }, { score: 0, member: "member" }]).command,
-        ["zadd", "key", "nx", "ch", 0, "member"],
-      );
+        new ZAddCommand(["key", { nx: true }, { score: 0, member: "member" }]).command
+      ).toEqual(["zadd", "key", "nx", 0, "member"]);
     });
   });
-  test("with nx,ch and incr", () => {
+
+  describe("with xx", () => {
+    test("build the correct command", () => {
+      expect(
+        new ZAddCommand(["key", { xx: true }, { score: 0, member: "member" }]).command
+      ).toEqual(["zadd", "key", "xx", 0, "member"]);
+    });
+  });
+
+  describe("with ch", () => {
+    test("build the correct command", () => {
+      expect(
+        new ZAddCommand(["key", { ch: true }, { score: 0, member: "member" }]).command
+      ).toEqual(["zadd", "key", "ch", 0, "member"]);
+    });
+  });
+
+  describe("with incr", () => {
+    test("build the correct command", () => {
+      expect(
+        new ZAddCommand(["key", { incr: true }, { score: 0, member: "member" }]).command
+      ).toEqual(["zadd", "key", "incr", 0, "member"]);
+    });
+  });
+
+  describe("with nx and ch", () => {
+    test("build the correct command", () => {
+      expect(
+        new ZAddCommand(["key", { nx: true, ch: true }, { score: 0, member: "member" }]).command
+      ).toEqual(["zadd", "key", "nx", "ch", 0, "member"]);
+    });
+  });
+
+  describe("with nx,ch and incr", () => {
     test("build the correct command", () => {
       expect(
         new ZAddCommand(["key", { nx: true, ch: true, incr: true }, { score: 0, member: "member" }])
-          .command,
-        ["zadd", "key", "nx", "ch", "incr", 0, "member"],
-      );
+          .command
+      ).toEqual(["zadd", "key", "nx", "ch", "incr", 0, "member"]);
     });
   });
-  test("with nx and multiple members", () => {
+
+  describe("with nx and multiple members", () => {
     test("build the correct command", () => {
       expect(
         new ZAddCommand([
@@ -89,14 +78,13 @@ test("command format", () => {
           { nx: true },
           { score: 0, member: "member" },
           { score: 1, member: "member1" },
-        ]).command,
-        ["zadd", "key", "nx", 0, "member", 1, "member1"],
-      );
+        ]).command
+      ).toEqual(["zadd", "key", "nx", 0, "member", 1, "member1"]);
     });
   });
 });
 
-test("without options", () => {
+describe("without options", () => {
   test("adds the member", async () => {
     const key = newKey();
     const member = randomID();
@@ -106,8 +94,8 @@ test("without options", () => {
   });
 });
 
-test("xx", () => {
-  test("when the element exists", () => {
+describe("xx", () => {
+  describe("when the element exists", () => {
     test("updates the element", async () => {
       const key = newKey();
       const member = randomID();
@@ -115,7 +103,7 @@ test("xx", () => {
       await new ZAddCommand([key, { score, member }]).exec(client);
       const newScore = score + 1;
       const res = await new ZAddCommand([key, { xx: true }, { score: newScore, member }]).exec(
-        client,
+        client
       );
       expect(res).toEqual(0);
 
@@ -123,7 +111,7 @@ test("xx", () => {
       expect(res2).toEqual(newScore);
     });
   });
-  test("when the element does not exist", () => {
+  describe("when the element does not exist", () => {
     test("does nothing", async () => {
       const key = newKey();
       const member = randomID();
@@ -131,15 +119,15 @@ test("xx", () => {
       await new ZAddCommand([key, { score, member }]).exec(client);
       const newScore = score + 1;
       const res = await new ZAddCommand([key, { xx: true }, { score: newScore, member }]).exec(
-        client,
+        client
       );
       expect(res).toEqual(0);
     });
   });
 });
 
-test("nx", () => {
-  test("when the element exists", () => {
+describe("nx", () => {
+  describe("when the element exists", () => {
     test("does nothing", async () => {
       const key = newKey();
       const member = randomID();
@@ -147,7 +135,7 @@ test("nx", () => {
       await new ZAddCommand([key, { score, member }]).exec(client);
       const newScore = score + 1;
       const res = await new ZAddCommand([key, { nx: true }, { score: newScore, member }]).exec(
-        client,
+        client
       );
       expect(res).toEqual(0);
 
@@ -155,7 +143,7 @@ test("nx", () => {
       expect(res2).toEqual(score);
     });
   });
-  test("when the element does not exist", () => {
+  describe("when the element does not exist", () => {
     test("creates element", async () => {
       const key = newKey();
       const member = randomID();
@@ -166,7 +154,7 @@ test("nx", () => {
   });
 });
 
-test("ch", () => {
+describe("ch", () => {
   test("returns the number of changed elements", async () => {
     const key = newKey();
     const member = randomID();
@@ -174,20 +162,20 @@ test("ch", () => {
     await new ZAddCommand([key, { score, member }]).exec(client);
     const newScore = score + 1;
     const res = await new ZAddCommand([key, { ch: true }, { score: newScore, member }]).exec(
-      client,
+      client
     );
     expect(res).toEqual(1);
   });
 });
 
-test("incr", () => {
+describe("incr", () => {
   test("increments the score", async () => {
     const key = newKey();
     const member = randomID();
     const score = Math.floor(Math.random() * 10);
     await new ZAddCommand([key, { score, member }]).exec(client);
     const res = await new ZAddCommand([key, { incr: true }, { score: 1, member }]).exec(client);
-    expect(typeof res, "number");
+    expect(typeof res).toBe("number");
     expect(res).toEqual(score + 1);
   });
 });

--- a/pkg/commands/zdiffstore.test.ts
+++ b/pkg/commands/zdiffstore.test.ts
@@ -9,6 +9,7 @@ const client = newHttpClient();
 
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
+
 test("stors the diff", async () => {
   const key1 = newKey();
   const key2 = newKey();
@@ -36,6 +37,6 @@ test("stors the diff", async () => {
   expect(res).toEqual(1);
 
   const zset3 = await new ZRangeCommand([out, 0, -1, { withScores: true }]).exec(client);
-  expect(zset3[0], "three");
-  expect(zset3[1], 3);
+  expect(zset3[0]).toBe("three");
+  expect(zset3[1]).toBe(3);
 });

--- a/pkg/commands/zinterstore.test.ts
+++ b/pkg/commands/zinterstore.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { ZAddCommand } from "./zadd";
 import { ZInterStoreCommand } from "./zinterstore";
 
@@ -9,10 +9,10 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("command format", () => {
-  test("without options", () => {
+describe("command format", () => {
+  describe("without options", () => {
     test("builds the correct command", () => {
-      expect(new ZInterStoreCommand(["destination", 1, "key"]).command, [
+      expect(new ZInterStoreCommand(["destination", 1, "key"]).command).toEqual([
         "zinterstore",
         "destination",
         1,
@@ -20,9 +20,9 @@ test("command format", () => {
       ]);
     });
   });
-  test("with multiple keys", () => {
+  describe("with multiple keys", () => {
     test("builds the correct command", () => {
-      expect(new ZInterStoreCommand(["destination", 2, ["key1", "key2"]]).command, [
+      expect(new ZInterStoreCommand(["destination", 2, ["key1", "key2"]]).command).toEqual([
         "zinterstore",
         "destination",
         2,
@@ -31,9 +31,9 @@ test("command format", () => {
       ]);
     });
   });
-  test("with single weight", () => {
+  describe("with single weight", () => {
     test("builds the correct command", () => {
-      expect(new ZInterStoreCommand(["destination", 1, "key", { weight: 4 }]).command, [
+      expect(new ZInterStoreCommand(["destination", 1, "key", { weight: 4 }]).command).toEqual([
         "zinterstore",
         "destination",
         1,
@@ -43,7 +43,7 @@ test("command format", () => {
       ]);
     });
   });
-  test("with multiple weights", () => {
+  describe("with multiple weights", () => {
     test("builds the correct command", () => {
       expect(
         new ZInterStoreCommand([
@@ -53,12 +53,11 @@ test("command format", () => {
           {
             weights: [2, 3],
           },
-        ]).command,
-        ["zinterstore", "destination", 2, "key1", "key2", "weights", 2, 3],
-      );
+        ]).command
+      ).toEqual(["zinterstore", "destination", 2, "key1", "key2", "weights", 2, 3]);
     });
-    test("with aggregate", () => {
-      test("sum", () => {
+    describe("with aggregate", () => {
+      describe("sum", () => {
         test("builds the correct command", () => {
           expect(
             new ZInterStoreCommand([
@@ -68,12 +67,11 @@ test("command format", () => {
               {
                 aggregate: "sum",
               },
-            ]).command,
-            ["zinterstore", "destination", 1, "key", "aggregate", "sum"],
-          );
+            ]).command
+          ).toEqual(["zinterstore", "destination", 1, "key", "aggregate", "sum"]);
         });
       });
-      test("min", () => {
+      describe("min", () => {
         test("builds the correct command", () => {
           expect(
             new ZInterStoreCommand([
@@ -83,12 +81,11 @@ test("command format", () => {
               {
                 aggregate: "min",
               },
-            ]).command,
-            ["zinterstore", "destination", 1, "key", "aggregate", "min"],
-          );
+            ]).command
+          ).toEqual(["zinterstore", "destination", 1, "key", "aggregate", "min"]);
         });
       });
-      test("max", () => {
+      describe("max", () => {
         test("builds the correct command", () => {
           expect(
             new ZInterStoreCommand([
@@ -98,13 +95,12 @@ test("command format", () => {
               {
                 aggregate: "max",
               },
-            ]).command,
-            ["zinterstore", "destination", 1, "key", "aggregate", "max"],
-          );
+            ]).command
+          ).toEqual(["zinterstore", "destination", 1, "key", "aggregate", "max"]);
         });
       });
     });
-    test("complex", () => {
+    describe("complex", () => {
       test("builds the correct command", () => {
         expect(
           new ZInterStoreCommand([
@@ -115,15 +111,25 @@ test("command format", () => {
               weights: [4, 2],
               aggregate: "max",
             },
-          ]).command,
-          ["zinterstore", "destination", 2, "key1", "key2", "weights", 4, 2, "aggregate", "max"],
-        );
+          ]).command
+        ).toEqual([
+          "zinterstore",
+          "destination",
+          2,
+          "key1",
+          "key2",
+          "weights",
+          4,
+          2,
+          "aggregate",
+          "max",
+        ]);
       });
     });
   });
 });
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the number of elements in the new set ", async () => {
     const destination = newKey();
     const key1 = newKey();
@@ -145,8 +151,8 @@ test("without options", () => {
   });
 });
 
-test("with weights", () => {
-  test("single weight", () => {
+describe("with weights", () => {
+  describe("single weight", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -174,7 +180,7 @@ test("with weights", () => {
       expect(res).toEqual(1);
     });
   });
-  test("multiple weight", () => {
+  describe("multiple weight", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -203,8 +209,8 @@ test("with weights", () => {
     });
   });
 });
-test("aggregate", () => {
-  test("sum", () => {
+describe("aggregate", () => {
+  describe("sum", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -232,7 +238,7 @@ test("aggregate", () => {
       expect(res).toEqual(1);
     });
   });
-  test("min", () => {
+  describe("min", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -260,7 +266,7 @@ test("aggregate", () => {
       expect(res).toEqual(1);
     });
   });
-  test("max", () => {
+  describe("max", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();

--- a/pkg/commands/zpopmax.test.ts
+++ b/pkg/commands/zpopmax.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { ZAddCommand } from "./zadd";
 import { ZPopMaxCommand } from "./zpopmax";
 
@@ -9,7 +9,7 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the max", async () => {
     const key = newKey();
     const score1 = 1;
@@ -22,13 +22,13 @@ test("without options", () => {
       { score: score2, member: member2 },
     ]).exec(client);
     const res = await new ZPopMaxCommand([key]).exec(client);
-    expect(res.length, 2);
-    expect(res![0], member2);
-    expect(res![1], score2);
+    expect(res.length).toBe(2);
+    expect(res![0]).toEqual(member2);
+    expect(res![1]).toEqual(score2);
   });
 });
 
-test("with count", () => {
+describe("with count", () => {
   test("returns the n max members", async () => {
     const key = newKey();
     const score1 = 1;

--- a/pkg/commands/zrange.test.ts
+++ b/pkg/commands/zrange.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { ZAddCommand } from "./zadd";
 import { ZRangeCommand } from "./zrange";
 const client = newHttpClient();
@@ -8,7 +8,7 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the set", async () => {
     const key = newKey();
     const score1 = 2;
@@ -24,12 +24,12 @@ test("without options", () => {
     ]).exec(client);
 
     const res = await new ZRangeCommand([key, 1, 3]).exec(client);
-    expect(res.length, 1);
-    expect(res![0], member2);
+    expect(res.length).toBe(1);
+    expect(res![0]).toEqual(member2);
   });
 });
 
-test("withscores", () => {
+describe("withscores", () => {
   test("returns the set", async () => {
     const key = newKey();
     const score1 = 2;
@@ -45,13 +45,13 @@ test("withscores", () => {
     ]).exec(client);
 
     const res = await new ZRangeCommand([key, 1, 3, { withScores: true }]).exec(client);
-    expect(res.length, 2);
-    expect(res![0], member2);
-    expect(res![1], score2);
+    expect(res.length).toBe(2);
+    expect(res![0]).toEqual(member2);
+    expect(res![1]).toEqual(score2);
   });
 });
 
-test("byscore", () => {
+describe("byscore", () => {
   test("returns the set", async () => {
     const key = newKey();
     const score1 = 1;
@@ -79,9 +79,9 @@ test("byscore", () => {
       },
     ]).exec(client);
 
-    expect(res.length, 2);
-    expect(res![0], member1);
-    expect(res![1], member2);
+    expect(res.length).toBe(2);
+    expect(res![0]).toEqual(member1);
+    expect(res![1]).toEqual(member2);
 
     const res2 = await new ZRangeCommand([
       key,
@@ -91,10 +91,10 @@ test("byscore", () => {
         byScore: true,
       },
     ]).exec(client);
-    expect(res2.length, 3);
-    expect(res2![0], member1);
-    expect(res2![1], member2);
-    expect(res2![2], member3);
+    expect(res2.length).toBe(3);
+    expect(res2![0]).toEqual(member1);
+    expect(res2![1]).toEqual(member2);
+    expect(res2![2]).toEqual(member3);
 
     const res3 = await new ZRangeCommand([
       key,
@@ -108,7 +108,7 @@ test("byscore", () => {
   });
 });
 
-test("bylex", () => {
+describe("bylex", () => {
   test("returns the set", async () => {
     const key = newKey();
 
@@ -121,9 +121,9 @@ test("bylex", () => {
 
     // everything in between a and c, excluding "a" and including "c"
     const res = await new ZRangeCommand([key, "(a", "[c", { byLex: true }]).exec(client);
-    expect(res.length, 2);
-    expect(res![0], "b");
-    expect(res![1], "c");
+    expect(res.length).toBe(2);
+    expect(res![0]).toBe("b");
+    expect(res![1]).toBe("c");
 
     //everything after "a", excluding a
     const res2 = await new ZRangeCommand([key, "(a", "+", { byLex: true }]).exec(client);
@@ -138,13 +138,13 @@ test("bylex", () => {
         byLex: true,
       },
     ]).exec(client);
-    expect(res3.length, 2);
-    expect(res3![0], "a");
-    expect(res3![1], "b");
+    expect(res3.length).toBe(2);
+    expect(res3![0]).toBe("a");
+    expect(res3![1]).toBe("b");
   });
 });
 
-test("rev", () => {
+describe("rev", () => {
   test("returns the set in reverse order", async () => {
     const key = newKey();
     const score1 = 2;
@@ -160,13 +160,13 @@ test("rev", () => {
     ]).exec(client);
 
     const res = await new ZRangeCommand([key, 0, 7, { rev: true }]).exec(client);
-    expect(res.length, 2);
-    expect(res![0], member2);
-    expect(res![1], member1);
+    expect(res.length).toBe(2);
+    expect(res![0]).toEqual(member2);
+    expect(res![1]).toEqual(member1);
   });
 });
 
-test("limit", () => {
+describe("limit", () => {
   test("returns only the first 2", async () => {
     const key = newKey();
     for (let i = 0; i < 10; i++) {
@@ -183,6 +183,6 @@ test("limit", () => {
         count: 2,
       },
     ]).exec(client);
-    expect(res.length, 2);
+    expect(res.length).toBe(2);
   });
 });

--- a/pkg/commands/zscan.test.ts
+++ b/pkg/commands/zscan.test.ts
@@ -1,35 +1,36 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { ZAddCommand } from "./zadd";
 import { ZScanCommand } from "./zscan";
 const client = newHttpClient();
 
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
-test("without options", () => {
+
+describe("without options", () => {
   test("returns cursor and members", async () => {
     const key = newKey();
     const value = randomID();
     await new ZAddCommand([key, { score: 0, member: value }]).exec(client);
     const res = await new ZScanCommand([key, 0]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
-test("with match", () => {
+describe("with match", () => {
   test("returns cursor and members", async () => {
     const key = newKey();
     const value = randomID();
     await new ZAddCommand([key, { score: 0, member: value }]).exec(client);
     const res = await new ZScanCommand([key, 0, { match: value }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });
 
@@ -40,8 +41,8 @@ test("with count", () => {
     await new ZAddCommand([key, { score: 0, member: value }]).exec(client);
     const res = await new ZScanCommand([key, 0, { count: 1 }]).exec(client);
 
-    expect(res.length, 2);
-    expect(typeof res[0], "number");
-    expect(res![1].length > 0, true);
+    expect(res.length).toBe(2);
+    expect(typeof res[0]).toBe("number");
+    expect(res![1].length > 0).toBe(true);
   });
 });

--- a/pkg/commands/zunion.test.ts
+++ b/pkg/commands/zunion.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 
 import { ZAddCommand } from "./zadd";
 import { ZUnionCommand } from "./zunion";
@@ -10,20 +10,25 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("command format", () => {
-  test("without options", () => {
+describe("command format", () => {
+  describe("without options", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionCommand([1, "key"]).command, ["zunion", 1, "key"]);
+      expect(new ZUnionCommand([1, "key"]).command).toEqual(["zunion", 1, "key"]);
     });
   });
-  test("with multiple keys", () => {
+  describe("with multiple keys", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionCommand([2, ["key1", "key2"]]).command, ["zunion", 2, "key1", "key2"]);
+      expect(new ZUnionCommand([2, ["key1", "key2"]]).command).toEqual([
+        "zunion",
+        2,
+        "key1",
+        "key2",
+      ]);
     });
   });
-  test("with single weight", () => {
+  describe("with single weight", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionCommand([1, "key", { weight: 4 }]).command, [
+      expect(new ZUnionCommand([1, "key", { weight: 4 }]).command).toEqual([
         "zunion",
         1,
         "key",
@@ -32,7 +37,7 @@ test("command format", () => {
       ]);
     });
   });
-  test("with multiple weights", () => {
+  describe("with multiple weights", () => {
     test("builds the correct command", () => {
       expect(
         new ZUnionCommand([
@@ -41,12 +46,11 @@ test("command format", () => {
           {
             weights: [2, 3],
           },
-        ]).command,
-        ["zunion", 2, "key1", "key2", "weights", 2, 3],
-      );
+        ]).command
+      ).toEqual(["zunion", 2, "key1", "key2", "weights", 2, 3]);
     });
-    test("with aggregate", () => {
-      test("sum", () => {
+    describe("with aggregate", () => {
+      describe("sum", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionCommand([
@@ -55,12 +59,11 @@ test("command format", () => {
               {
                 aggregate: "sum",
               },
-            ]).command,
-            ["zunion", 1, "key", "aggregate", "sum"],
-          );
+            ]).command
+          ).toEqual(["zunion", 1, "key", "aggregate", "sum"]);
         });
       });
-      test("min", () => {
+      describe("min", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionCommand([
@@ -69,12 +72,11 @@ test("command format", () => {
               {
                 aggregate: "min",
               },
-            ]).command,
-            ["zunion", 1, "key", "aggregate", "min"],
-          );
+            ]).command
+          ).toEqual(["zunion", 1, "key", "aggregate", "min"]);
         });
       });
-      test("max", () => {
+      describe("max", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionCommand([
@@ -83,13 +85,12 @@ test("command format", () => {
               {
                 aggregate: "max",
               },
-            ]).command,
-            ["zunion", 1, "key", "aggregate", "max"],
-          );
+            ]).command
+          ).toEqual(["zunion", 1, "key", "aggregate", "max"]);
         });
       });
     });
-    test("complex", () => {
+    describe("complex", () => {
       test("builds the correct command", () => {
         expect(
           new ZUnionCommand([
@@ -99,15 +100,14 @@ test("command format", () => {
               weights: [4, 2],
               aggregate: "max",
             },
-          ]).command,
-          ["zunion", 2, "key1", "key2", "weights", 4, 2, "aggregate", "max"],
-        );
+          ]).command
+        ).toEqual(["zunion", 2, "key1", "key2", "weights", 4, 2, "aggregate", "max"]);
       });
     });
   });
 });
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the union", async () => {
     const key1 = newKey();
     const key2 = newKey();
@@ -121,12 +121,12 @@ test("without options", () => {
 
     const res = await new ZUnionCommand([2, [key1, key2]]).exec(client);
 
-    expect(res.length, 2);
-    expect(res?.sort(), [member1, member2].sort());
+    expect(res.length).toBe(2);
+    expect(res?.sort()).toEqual([member1, member2].sort());
   });
 });
 
-test("with weights", () => {
+describe("with weights", () => {
   test("returns the set", async () => {
     const key1 = newKey();
     const key2 = newKey();
@@ -147,12 +147,12 @@ test("with weights", () => {
       },
     ]).exec(client);
 
-    expect(res.length, 2);
+    expect(res.length).toBe(2);
   });
 });
 
-test("aggregate", () => {
-  test("sum", () => {
+describe("aggregate", () => {
+  describe("sum", () => {
     test("returns the set", async () => {
       const key1 = newKey();
       const key2 = newKey();
@@ -172,11 +172,11 @@ test("aggregate", () => {
         },
       ]).exec(client);
 
-      expect(Array.isArray(res), true);
-      expect(res.length, 2);
+      expect(Array.isArray(res)).toBe(true);
+      expect(res.length).toBe(2);
     });
   });
-  test("min", () => {
+  describe("min", () => {
     test("returns the set ", async () => {
       const key1 = newKey();
       const key2 = newKey();
@@ -195,10 +195,10 @@ test("aggregate", () => {
           aggregate: "min",
         },
       ]).exec(client);
-      expect(res.length, 2);
+      expect(res.length).toBe(2);
     });
   });
-  test("max", () => {
+  describe("max", () => {
     test("returns the set ", async () => {
       const key1 = newKey();
       const key2 = newKey();
@@ -217,12 +217,12 @@ test("aggregate", () => {
           aggregate: "max",
         },
       ]).exec(client);
-      expect(res.length, 2);
+      expect(res.length).toBe(2);
     });
   });
 });
 
-test("withscores", () => {
+describe("withscores", () => {
   test("returns the set", async () => {
     const key1 = newKey();
     const score1 = 1;
@@ -244,8 +244,8 @@ test("withscores", () => {
       },
     ]).exec(client);
 
-    expect(res.length, 4);
-    expect(res[0], member1);
-    expect(res[1], score1);
+    expect(res.length).toBe(4);
+    expect(res[0]).toEqual(member1);
+    expect(res[1]).toEqual(score1);
   });
 });

--- a/pkg/commands/zunionstore.test.ts
+++ b/pkg/commands/zunionstore.test.ts
@@ -1,6 +1,6 @@
 import { keygen, newHttpClient, randomID } from "../test-utils";
 
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 
 import { ZAddCommand } from "./zadd";
 import { ZUnionStoreCommand } from "./zunionstore";
@@ -10,10 +10,10 @@ const client = newHttpClient();
 const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 
-test("command format", () => {
-  test("without options", () => {
+describe("command format", () => {
+  describe("without options", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionStoreCommand(["destination", 1, "key"]).command, [
+      expect(new ZUnionStoreCommand(["destination", 1, "key"]).command).toEqual([
         "zunionstore",
         "destination",
         1,
@@ -21,9 +21,9 @@ test("command format", () => {
       ]);
     });
   });
-  test("with multiple keys", () => {
+  describe("with multiple keys", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionStoreCommand(["destination", 2, ["key1", "key2"]]).command, [
+      expect(new ZUnionStoreCommand(["destination", 2, ["key1", "key2"]]).command).toEqual([
         "zunionstore",
         "destination",
         2,
@@ -32,9 +32,9 @@ test("command format", () => {
       ]);
     });
   });
-  test("with single weight", () => {
+  describe("with single weight", () => {
     test("builds the correct command", () => {
-      expect(new ZUnionStoreCommand(["destination", 1, "key", { weight: 4 }]).command, [
+      expect(new ZUnionStoreCommand(["destination", 1, "key", { weight: 4 }]).command).toEqual([
         "zunionstore",
         "destination",
         1,
@@ -44,7 +44,7 @@ test("command format", () => {
       ]);
     });
   });
-  test("with multiple weights", () => {
+  describe("with multiple weights", () => {
     test("builds the correct command", () => {
       expect(
         new ZUnionStoreCommand([
@@ -54,12 +54,11 @@ test("command format", () => {
           {
             weights: [2, 3],
           },
-        ]).command,
-        ["zunionstore", "destination", 2, "key1", "key2", "weights", 2, 3],
-      );
+        ]).command
+      ).toEqual(["zunionstore", "destination", 2, "key1", "key2", "weights", 2, 3]);
     });
-    test("with aggregate", () => {
-      test("sum", () => {
+    describe("with aggregate", () => {
+      describe("sum", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionStoreCommand([
@@ -69,12 +68,11 @@ test("command format", () => {
               {
                 aggregate: "sum",
               },
-            ]).command,
-            ["zunionstore", "destination", 1, "key", "aggregate", "sum"],
-          );
+            ]).command
+          ).toEqual(["zunionstore", "destination", 1, "key", "aggregate", "sum"]);
         });
       });
-      test("min", () => {
+      describe("min", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionStoreCommand([
@@ -84,12 +82,11 @@ test("command format", () => {
               {
                 aggregate: "min",
               },
-            ]).command,
-            ["zunionstore", "destination", 1, "key", "aggregate", "min"],
-          );
+            ]).command
+          ).toEqual(["zunionstore", "destination", 1, "key", "aggregate", "min"]);
         });
       });
-      test("max", () => {
+      describe("max", () => {
         test("builds the correct command", () => {
           expect(
             new ZUnionStoreCommand([
@@ -99,13 +96,12 @@ test("command format", () => {
               {
                 aggregate: "max",
               },
-            ]).command,
-            ["zunionstore", "destination", 1, "key", "aggregate", "max"],
-          );
+            ]).command
+          ).toEqual(["zunionstore", "destination", 1, "key", "aggregate", "max"]);
         });
       });
     });
-    test("complex", () => {
+    describe("complex", () => {
       test("builds the correct command", () => {
         expect(
           new ZUnionStoreCommand([
@@ -116,15 +112,25 @@ test("command format", () => {
               weights: [4, 2],
               aggregate: "max",
             },
-          ]).command,
-          ["zunionstore", "destination", 2, "key1", "key2", "weights", 4, 2, "aggregate", "max"],
-        );
+          ]).command
+        ).toEqual([
+          "zunionstore",
+          "destination",
+          2,
+          "key1",
+          "key2",
+          "weights",
+          4,
+          2,
+          "aggregate",
+          "max",
+        ]);
       });
     });
   });
 });
 
-test("without options", () => {
+describe("without options", () => {
   test("returns the number of elements in the new set ", async () => {
     const destination = newKey();
     const key1 = newKey();
@@ -142,8 +148,8 @@ test("without options", () => {
   });
 });
 
-test("with weights", () => {
-  test("single weight", () => {
+describe("with weights", () => {
+  describe("single weight", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -167,7 +173,7 @@ test("with weights", () => {
       expect(res).toEqual(2);
     });
   });
-  test("multiple weight", () => {
+  describe("multiple weight", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -192,8 +198,8 @@ test("with weights", () => {
     });
   });
 });
-test("aggregate", () => {
-  test("sum", () => {
+describe("aggregate", () => {
+  describe("sum", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -217,7 +223,7 @@ test("aggregate", () => {
       expect(res).toEqual(2);
     });
   });
-  test("min", () => {
+  describe("min", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();
@@ -241,7 +247,7 @@ test("aggregate", () => {
       expect(res).toEqual(2);
     });
   });
-  test("max", () => {
+  describe("max", () => {
     test("returns the number of elements in the new set ", async () => {
       const destination = newKey();
       const key1 = newKey();


### PR DESCRIPTION
Some of the import paths and assertions are missing.And, some assertions are hiding under those falsy assertions. We had to add necessary `toBe`'s and `toEquals`'s
```

expect(res.length, 2);
expect(typeof res[0], "number");
expect(res![1].length > 0, true);
```
