### PR TITLE
fix: add file extensions

### DIFF
--- a/pkg/script.ts
+++ b/pkg/script.ts
@@ -1,5 +1,5 @@
-import Hex from "crypto-js/enc-hex";
-import sha1 from "crypto-js/sha1";
+import Hex from "crypto-js/enc-hex.js";
+import sha1 from "crypto-js/sha1.js";
 import { Redis } from "./redis";
 /**
  * Creates a new script.


### PR DESCRIPTION
This ought to fix https://github.com/upstash/upstash-redis/issues/698.

I think, error is related to the way TypeScript and Node.js handle module resolution and imports, particularly in relation to the ECMAScript modules.

When set to bundler, TypeScript is told that the code will be bundled by another tool, so it loosens the rules with imports, allowing imports without file extensions or with `.ts` extensions​. This is especially useful for projects that will be bundled using tools like Webpack, Rollup, or others, as it aligns with the way these tools resolve modules.
However, it's important to note that while TypeScript allows for omitting extensions with the bundler option, Node.js and in-browser JavaScript still expect file extensions to be present for ESM. This is because, in the world of ESM, file extensions cannot be omitted​.