### PR TITLE
Fix GEOSEARCH Command when Limit is set

### DIFF
--- a/pkg/commands/geo_search.test.ts
+++ b/pkg/commands/geo_search.test.ts
@@ -175,4 +175,23 @@ describe("GEOSEARCH tests", () => {
       },
     ]);
   });
+
+  test("should return one member, with count set", async () => {
+    const key = newKey();
+    await new GeoAddCommand([
+      key,
+      { longitude: 13.361389, latitude: 38.115556, member: "Palermo" },
+      { longitude: 15.087269, latitude: 37.502669, member: "Catania" },
+    ]).exec(client);
+
+    const res = await new GeoSearchCommand([
+      key,
+      { type: "FROMLONLAT", coordinate: { lon: 15, lat: 37 } },
+      { type: "BYRADIUS", radius: 200, radiusType: "KM" },
+      "ASC",
+      { count: { limit: 1 } },
+    ]).exec(client);
+
+    expect(res).toEqual([{ member: "Catania" }]);
+  });
 });

--- a/pkg/commands/geo_search.ts
+++ b/pkg/commands/geo_search.ts
@@ -84,7 +84,7 @@ export class GeoSearchCommand<
     command.push(order);
 
     if (opts?.count) {
-      command.push(opts.count.limit, ...(opts.count.any ? ["ANY"] : []));
+      command.push("COUNT", opts.count.limit, ...(opts.count.any ? ["ANY"] : []));
     }
 
     const transform = (result: string[] | string[][]) => {

--- a/pkg/commands/geo_search_store.ts
+++ b/pkg/commands/geo_search_store.ts
@@ -60,7 +60,7 @@ export class GeoSearchStoreCommand<
     command.push(order);
 
     if (opts?.count) {
-      command.push(opts.count.limit, ...(opts.count.any ? ["ANY"] : []));
+      command.push("COUNT", opts.count.limit, ...(opts.count.any ? ["ANY"] : []));
     }
 
     super([...command, ...(opts?.storeDist ? ["STOREDIST"] : [])], commandOptions);


### PR DESCRIPTION
The `COUNT`  (both on GEOSEARCH and GEOSEARCHSTORE) was missing according the official Redis Docs: https://redis.io/commands/geosearch/

I need this change to improve performance on my application with working COUNT Limit.

Before the fix, I got the following error:

```
[UpstashError]: ERR syntax error, command was: ["GEOSEARCH","cache:hotels:geo-index","FROMLONLAT",-8.672491,37.10109,"BYRADIUS",10,"KM","ASC",50]
```