### PR TITLE
DX-531: Add esm to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@upstash/redis",
   "version": "0.0.0-canary.2",
   "main": "./nodejs.js",
+  "module": "./nodejs.mjs",
   "types": "./nodejs.d.ts",
   "description": "An HTTP/REST based Redis client built on top of Upstash REST API.",
   "repository": {


### PR DESCRIPTION
Fixes #774
`module` field was missing from the `package.json` so `.mjs` files were not chosen
