### PR TITLE
chore: add setup-bun action to workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Install bun
-        run: npm i -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Set package version
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,11 +20,6 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -48,13 +50,11 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -92,13 +92,11 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -141,8 +139,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - uses: pnpm/action-setup@v2
         with:
@@ -174,8 +174,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - uses: pnpm/action-setup@v2
         with:
@@ -205,8 +207,10 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -242,8 +246,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Install bun
-        run: npm install -g bun
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -295,8 +302,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install example
         run: |
@@ -331,8 +340,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -385,8 +396,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install example
         run: |
@@ -423,15 +436,14 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
-
       - uses: pnpm/action-setup@v2
         with:
           version: latest
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install Dependencies
         run: bun install
@@ -479,8 +491,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Install bun
-        run: npm install -g bun
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Cache pnpm modules
         uses: actions/cache@v2
         with:
@@ -533,8 +549,11 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Install Dependencies
         run: bun install
 
@@ -576,8 +595,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install bun
-        run: npm install -g bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Set version
         run: |


### PR DESCRIPTION
It might be better to use the official `bun` action directly for the workflow.

In this way, we will not need to install the `setup-node` in actions where `npm` is not required. 

Just `bun` may be enough.