### PR TITLE
feat: Added a timeout option instead of signal in HttpClientConfig

### DIFF
--- a/pkg/http.test.ts
+++ b/pkg/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test, type Mock } from "bun:test";
 import { HttpClient } from "./http";
 
 import { newHttpClient } from "./test-utils";
@@ -35,15 +35,17 @@ describe(new URL("", import.meta.url).pathname, () => {
 
 describe("Abort", () => {
   test("should abort the request", async () => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
     const client = newHttpClient();
-    client.options.signal = signal;
+    client.options.timeout = 1000;
+
+    global.fetch = mock((_url, requestOptions) => {
+      requestOptions.signal = AbortSignal.abort("Abort works!");
+      return Promise.reject();
+    });
     const body = client.request({
       body: ["set", "name", "hezarfen"],
     });
-    controller.abort("Abort works!");
+    (global.fetch as Mock<typeof fetch>).mockClear();
 
     expect((await body).result).toEqual("Abort works!");
   });

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -23,10 +23,10 @@ export type RedisConfigCloudflare = {
    */
   token: string;
   /**
-   * The signal will allow aborting requests on the fly.
-   * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+   * The timeout(msec) will allow aborting requests on the fly.
+   * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
    */
-  signal?: AbortSignal;
+  timeout?: number;
 } & core.RedisOptions &
   RequesterConfig &
   Env;
@@ -71,7 +71,7 @@ export class Redis extends core.Redis {
       baseUrl: config.url,
       headers: { authorization: `Bearer ${config.token}` },
       responseEncoding: config.responseEncoding,
-      signal: config.signal,
+      timeout: config.timeout,
     });
 
     super(client, {

--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -51,10 +51,10 @@ export type RedisConfigNodejs = {
    * ```
    */
   /**
-   * The signal will allow aborting requests on the fly.
+   * The timeout(msec) will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
-  signal?: AbortSignal;
+  timeout?: number;
   agent?: any;
 } & core.RedisOptions &
   RequesterConfig;
@@ -125,7 +125,7 @@ export class Redis extends core.Redis {
       agent: configOrRequester.agent,
       responseEncoding: configOrRequester.responseEncoding,
       cache: configOrRequester.cache || "no-store",
-      signal: configOrRequester.signal,
+      timeout: configOrRequester.timeout,
     });
 
     super(client, {


### PR DESCRIPTION
In most use cases, the AbortController should be new for each fetch request and should not be stored as a HttpClientConfig.

ref: https://github.com/upstash/upstash-redis/issues/778#issuecomment-1861059008