### PR TITLE
Fix detection unsafe integer

### DIFF
--- a/pkg/commands/hgetall.ts
+++ b/pkg/commands/hgetall.ts
@@ -11,7 +11,7 @@ function deserialize<TData extends Record<string, unknown>>(result: string[]): T
     try {
       // handle unsafe integer
       const valueIsNumberAndNotSafeInteger =
-        !Number.isNaN(Number(value)) && !Number.isSafeInteger(value);
+        !Number.isNaN(Number(value)) && !Number.isSafeInteger(Number(value));
       if (valueIsNumberAndNotSafeInteger) {
         obj[key] = value;
       } else {


### PR DESCRIPTION
Closes #1047

`Number.isSafeInteger('50')` returns `false`
`Number.isSafeInteger(50)` returns `true`