### PR TITLE
fix: filter falsy values before sending request

### DIFF
--- a/pkg/commands/expire.ts
+++ b/pkg/commands/expire.ts
@@ -6,6 +6,6 @@ export class ExpireCommand extends Command<"0" | "1", 0 | 1> {
     cmd: [key: string, seconds: number, option?: ExpireOptions],
     opts?: CommandOptions<"0" | "1", 0 | 1>,
   ) {
-    super(["expire", ...cmd], opts);
+    super(["expire", ...cmd.filter(Boolean)], opts);
   }
 }


### PR DESCRIPTION
Implicit undefined values as the expiry option work, however passing an explicit undefined to our `expire` command is possible on the type-level but leads to a runtime error. This PR allows explicit undefined values by filtering them in our SDK before submitting.