### PR TITLE
Allow undefined constructor values

### DIFF
--- a/pkg/auto-pipeline.test.ts
+++ b/pkg/auto-pipeline.test.ts
@@ -1,9 +1,8 @@
-import { Redis } from "../platforms/nodejs"
+import { Redis } from "../platforms/nodejs";
 import { keygen, newHttpClient } from "./test-utils";
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { ScriptLoadCommand } from "./commands/script_load";
-
 
 const client = newHttpClient();
 
@@ -17,10 +16,10 @@ describe("Auto pipeline", () => {
     const scriptHash = await new ScriptLoadCommand(["return 1"]).exec(client);
 
     const redis = Redis.autoPipeline({
-      latencyLogging: false
-    })
+      latencyLogging: false,
+    });
     // @ts-expect-error pipelineCounter is not in type but accessible
-    expect(redis.pipelineCounter).toBe(0)
+    expect(redis.pipelineCounter).toBe(0);
 
     // all the following commands are in a single pipeline call
     const result = await Promise.all([
@@ -143,19 +142,18 @@ describe("Auto pipeline", () => {
       redis.zscore(newKey(), "member"),
       redis.zunionstore(newKey(), 1, [newKey()]),
       redis.zunion(1, [newKey()]),
-      redis.json.set(newKey(), "$", { hello: "world" })
-    ])
+      redis.json.set(newKey(), "$", { hello: "world" }),
+    ]);
     expect(result).toBeTruthy();
-    expect(result.length).toBe(120); // returns 
+    expect(result.length).toBe(120); // returns
     // @ts-expect-error pipelineCounter is not in type but accessible120 results
     expect(redis.pipelineCounter).toBe(1);
   });
 
   test("should group async requests with sync requests", async () => {
-
     const redis = Redis.autoPipeline({
-      latencyLogging: false
-    })
+      latencyLogging: false,
+    });
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(0);
 
@@ -168,21 +166,17 @@ describe("Auto pipeline", () => {
 
     // two get calls are added to the pipeline and pipeline
     // is executed since we called await
-    const [fooValue, bazValue] = await Promise.all([
-      redis.get("foo"),
-      redis.get("baz")
-    ]);
+    const [fooValue, bazValue] = await Promise.all([redis.get("foo"), redis.get("baz")]);
 
     expect(fooValue).toBe("bar");
     expect(bazValue).toBe(3);
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(1);
-  })
+  });
 
   test("should execute a pipeline for each consecutive awaited command", async () => {
-
     const redis = Redis.autoPipeline({
-      latencyLogging: false
+      latencyLogging: false,
     });
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(0);
@@ -202,13 +196,11 @@ describe("Auto pipeline", () => {
     expect(redis.pipelineCounter).toBe(3);
 
     expect([res1, res2, res3]).toEqual([1, 2, "OK"]);
-
   });
 
   test("should execute a single pipeline for several commands inside Promise.all", async () => {
-
     const redis = Redis.autoPipeline({
-      latencyLogging: false
+      latencyLogging: false,
     });
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(0);
@@ -218,11 +210,10 @@ describe("Auto pipeline", () => {
       redis.incr("baz"),
       redis.incr("baz"),
       redis.set("foo", "bar"),
-      redis.get("foo")
+      redis.get("foo"),
     ]);
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(1);
     expect(resArray).toEqual(["OK", 1, 2, "OK", "bar"]);
-
-  })
+  });
 });

--- a/pkg/auto-pipeline.ts
+++ b/pkg/auto-pipeline.ts
@@ -1,26 +1,24 @@
 import { Command } from "./commands/command";
-import { CommandArgs } from "./types";
 import { Pipeline } from "./pipeline";
 import { Redis } from "./redis";
+import { CommandArgs } from "./types";
 
 // will omit redis only commands since we call Pipeline in the background in auto pipeline
-type redisOnly = Exclude<keyof Redis, keyof Pipeline>
+type redisOnly = Exclude<keyof Redis, keyof Pipeline>;
 
 export function createAutoPipelineProxy(_redis: Redis) {
-
   const redis = _redis as Redis & {
     autoPipelineExecutor: AutoPipelineExecutor;
-  }
+  };
 
   if (!redis.autoPipelineExecutor) {
     redis.autoPipelineExecutor = new AutoPipelineExecutor(redis);
   }
 
   return new Proxy(redis, {
-    get: (target, prop: "pipelineCounter" | keyof Pipeline ) => {
-
+    get: (target, prop: "pipelineCounter" | keyof Pipeline) => {
       // return pipelineCounter of autoPipelineExecutor
-      if (prop == "pipelineCounter") {
+      if (prop === "pipelineCounter") {
         return target.autoPipelineExecutor.pipelineCounter;
       }
 
@@ -43,7 +41,7 @@ export class AutoPipelineExecutor {
   private indexInCurrentPipeline = 0;
   private redis: Redis;
   pipeline: Pipeline; // only to make sure that proxy can work
-  pipelineCounter: number = 0; // to keep track of how many times a pipeline was executed 
+  pipelineCounter = 0; // to keep track of how many times a pipeline was executed
 
   constructor(redis: Redis) {
     this.redis = redis;

--- a/pkg/redis.ts
+++ b/pkg/redis.ts
@@ -1,3 +1,4 @@
+import { createAutoPipelineProxy } from "../pkg/auto-pipeline";
 import {
   AppendCommand,
   BitCountCommand,
@@ -175,7 +176,6 @@ import { Requester, UpstashRequest, UpstashResponse } from "./http";
 import { Pipeline } from "./pipeline";
 import { Script } from "./script";
 import type { CommandArgs, RedisOptions, Telemetry } from "./types";
-import { AutoPipelineExecutor, createAutoPipelineProxy } from "../pkg/auto-pipeline"
 
 // See https://github.com/upstash/upstash-redis/issues/342
 // why we need this export
@@ -380,7 +380,7 @@ export class Redis {
     });
 
   autoPipeline = () => {
-    return createAutoPipelineProxy(this)
+    return createAutoPipelineProxy(this);
   };
 
   /**

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -17,11 +17,11 @@ export type RedisConfigCloudflare = {
   /**
    * UPSTASH_REDIS_REST_URL
    */
-  url: string;
+  url: string | undefined;
   /**
    * UPSTASH_REDIS_REST_TOKEN
    */
-  token: string;
+  token: string | undefined;
   /**
    * The signal will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
@@ -47,6 +47,14 @@ export class Redis extends core.Redis {
    * ```
    */
   constructor(config: RedisConfigCloudflare, env?: Env) {
+    if(!config.url) {
+      throw new Error(`[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`)
+    }
+
+    if(!config.token) {
+      throw new Error(`[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`)
+    }
+
     if (config.url.startsWith(" ") || config.url.endsWith(" ") || /\r|\n/.test(config.url)) {
       console.warn("The redis url contains whitespace or newline, which can cause errors!");
     }

--- a/platforms/fastly.ts
+++ b/platforms/fastly.ts
@@ -14,11 +14,11 @@ export type RedisConfigFastly = {
   /**
    * UPSTASH_REDIS_REST_URL
    */
-  url: string;
+  url: string | undefined;
   /**
    * UPSTASH_REDIS_REST_TOKEN
    */
-  token: string;
+  token: string | undefined;
   /**
    * A Request can be forwarded to any backend defined on your service. Backends
    * can be created via the Fastly CLI, API, or web interface, and are
@@ -45,6 +45,14 @@ export class Redis extends core.Redis {
    * ```
    */
   constructor(config: RedisConfigFastly) {
+    if(!config.url) {
+      throw new Error(`[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`)
+    }
+
+    if(!config.token) {
+      throw new Error(`[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`)
+    }
+
     if (config.url.startsWith(" ") || config.url.endsWith(" ") || /\r|\n/.test(config.url)) {
       console.warn("The redis url contains whitespace or newline, which can cause errors!");
     }

--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -27,11 +27,11 @@ export type RedisConfigNodejs = {
   /**
    * UPSTASH_REDIS_REST_URL
    */
-  url: string;
+  url: string | undefined;
   /**
    * UPSTASH_REDIS_REST_TOKEN
    */
-  token: string;
+  token: string | undefined;
 
   /**
    * An agent allows you to reuse connections to reduce latency for multiple sequential requests.
@@ -98,6 +98,15 @@ export class Redis extends core.Redis {
       super(configOrRequester);
       return;
     }
+
+    if(!configOrRequester.url) {
+      throw new Error(`[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`)
+    }
+
+    if(!configOrRequester.token) {
+      throw new Error(`[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`)
+    }
+
     if (
       configOrRequester.url.startsWith(" ") ||
       configOrRequester.url.endsWith(" ") ||


### PR DESCRIPTION
instead of enforcing string values to init Redis, we now accept undefined values and provide a runtime error if the init was not called with actual string values for `url` and `token`.

(unrelated) some files were not formatted, included proper formatting in this pr