### PR TITLE
Add .ready promise to Subscriber

### DIFF
--- a/pkg/commands/psubscribe.test.ts
+++ b/pkg/commands/psubscribe.test.ts
@@ -23,7 +23,7 @@ describe("Pattern Subscriber", () => {
       receivedMessages.push(message);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     const testMessage: TestMessage = {
       user: "testUser",
@@ -52,7 +52,7 @@ describe("Pattern Subscriber", () => {
       messages.push(data);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     await redis.publish("chat:room1:messages", { msg: "Hello Room 1" });
     await redis.publish("chat:room2:messages", { msg: "Hello Room 2" });
@@ -81,7 +81,7 @@ describe("Pattern Subscriber", () => {
       messages[pattern].push({ channel, message });
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     await redis.publish("user:123", { type: "user" });
     await redis.publish("chat:room1", { type: "chat" });
@@ -108,7 +108,7 @@ describe("Pattern Subscriber", () => {
       messages[pattern].push({ channel, message });
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     // Initial messages
     await redis.publish("user:123", { msg: "user1" });
@@ -153,7 +153,8 @@ describe("Pattern Subscriber", () => {
       channelMessages.push(message);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await patternSubscriber.ready;
+    await channelSubscriber.ready;
 
     const testMessage: TestMessage = { msg: "Hello" };
     await redis.publish("user:123", testMessage);

--- a/pkg/commands/subscribe.test.ts
+++ b/pkg/commands/subscribe.test.ts
@@ -16,7 +16,7 @@ describe("Subscriber", () => {
     });
 
     // Wait for subscription to establish
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     const testMessage = {
       user: "testUser",
@@ -42,7 +42,7 @@ describe("Subscriber", () => {
       receivedMessages.push(data.message);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     const messages = [
       { user: "user1", message: "First", timestamp: Date.now() },
@@ -72,7 +72,7 @@ describe("Subscriber", () => {
       channelMessages.push(data.message);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     const testMessage = {
       user: "testUser",
@@ -100,7 +100,8 @@ describe("Subscriber", () => {
     subscriber1.on("message", (data) => messages1.push(data.message));
     subscriber2.on("message", (data) => messages2.push(data.message));
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber1.ready;
+    await subscriber2.ready;
 
     const testMessage = {
       user: "testUser",
@@ -131,7 +132,7 @@ describe("Subscriber", () => {
       messages[data.channel].push(data.message);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await subscriber.ready;
 
     // Send initial messages to both channels
     await redis.publish("channel1", { test: "before1" });


### PR DESCRIPTION
Background: Most commands return a promise that resolves when the command is complete/executed and its result can be relied upon, however `.subscribe` and `.psubscribe` return `Subscriber` instances before the `SUBSCRIBE` commands have completed their round trip to Redis, so it’s hard to know when the subscription(s) are ready, connected, and listening. This problem can be seen in the tests, which used a 500ms delay to try to ensure that the subscription was ready before sending `PUBLISH` commands

As an alternative, **this PR adds a `.ready` property to `Subscriber`** which clients can `await` to know when the subscription(s) are ready, i.e. when it’s safe to start `publish`ing commands.

- I’m not sure whether `.ready` is the best name for this promise
- this is my first contribution so I’m not sure whether there’s anything I’m missing design-wise
- I updated the tests with the intended usage