### PR TITLE
test: fix auto pipeline test

### DIFF
--- a/packages/redis/pkg/auto-pipeline.test.ts
+++ b/packages/redis/pkg/auto-pipeline.test.ts
@@ -41,8 +41,6 @@ describe("Auto pipeline", () => {
       redis.exists(newKey()),
       redis.expire(newKey(), 5),
       redis.expireat(newKey(), Math.floor(Date.now() / 1000) + 60),
-      redis.flushall(),
-      redis.flushdb(),
       redis.get(newKey()),
       redis.getbit(newKey(), 0),
       redis.getdel(newKey()),
@@ -160,7 +158,7 @@ describe("Auto pipeline", () => {
       redis.json.merge(persistentKey3, "$.log", '"three"'),
     ]);
     expect(result).toBeTruthy();
-    expect(result.length).toBe(133); // returns
+    expect(result.length).toBe(131); // returns
 
     // @ts-expect-error pipelineCounter is not in type but accessible results
     expect(redis.pipelineCounter).toBe(1);


### PR DESCRIPTION
`flushdb` and `flushall` are not pipeline commands, and they can run concurrently
with other pipelined commands in the test. This can lead to a race where an expected key
is deleted before it is read, resulting in a failed test.

Sample failure:

```
pkg/auto-pipeline.test.ts:
  135 |     const results = (await pipelineDone) as UpstashResponse<T>[];
  136 |     const commandResult = results[index];
  137 |     if (commandResult.error) {
  > Killing server 5389
  138 |       throw new UpstashError(`Command failed: ${commandResult.error}`);
                    ^
  UpstashError: Command failed: ERR no such key
        at withAutoPipeline (/tmp/upstash-redis-js/packages/redis/pkg/auto-pipeline.ts:138:13)
        at async <anonymous> (/tmp/upstash-redis-js/packages/redis/pkg/auto-pipeline.test.ts:27:34)
```
