### PR TITLE
fix: add allowBuilds for pnpm 11 compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,8 @@ blockExoticSubdeps: true
 
 onlyBuiltDependencies:
   - esbuild
+
+allowBuilds:
+  esbuild: true
+
 # trustPolicy: no-downgrade


### PR DESCRIPTION
pnpm 11 removed onlyBuiltDependencies in favor of allowBuilds. Keeping both keys so installs work on pnpm 10 and pnpm 11.