### PR TITLE
DX-2866: add start-redis tip to missing url/token warnings

### DIFF
--- a/.changeset/start-redis-tip-in-warnings.md
+++ b/.changeset/start-redis-tip-in-warnings.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": patch
+---
+
+Add a quick tip about creating a database via https://upstash.com/start-redis to the warnings shown when the Redis url or token is missing

--- a/.changeset/start-redis-tip-in-warnings.md
+++ b/.changeset/start-redis-tip-in-warnings.md
@@ -2,4 +2,4 @@
 "@upstash/redis": patch
 ---
 
-Add a quick tip about creating a database via https://upstash.com/start-redis to the warnings shown when the Redis url or token is missing
+Add a quick tip about creating a database via https://upstash.com/start-redis to the warnings shown when the Redis url or token is missing. On Cloudflare, the warning shown when both the url and the token are missing now names both `wrangler secret put` commands instead of only one.

--- a/packages/redis/platforms/cloudflare.ts
+++ b/packages/redis/platforms/cloudflare.ts
@@ -140,18 +140,18 @@ export class Redis extends core.Redis {
           UPSTASH_REDIS_REST_TOKEN
         : undefined);
 
-    const messageInfo =
-      !url && !token
-        ? "Unable to find environment variables: `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`"
-        : url
-          ? token
-            ? undefined
-            : "Unable to find environment variable: `UPSTASH_REDIS_REST_TOKEN`"
-          : "Unable to find environment variable: `UPSTASH_REDIS_REST_URL`";
+    const missing: string[] = [];
+    if (!url) missing.push("UPSTASH_REDIS_REST_URL");
+    if (!token) missing.push("UPSTASH_REDIS_REST_TOKEN");
 
-    if (messageInfo) {
+    if (missing.length > 0) {
+      // Both can be missing at once, so the wording and the number of
+      // `wrangler secret put` commands follow how many are actually missing.
+      const plural = missing.length > 1;
+      const names = missing.map((name) => `\`${name}\``).join(" and ");
+      const commands = missing.map((name) => `\`wrangler secret put ${name}\``).join(" and ");
       console.warn(
-        `[Upstash Redis] ${messageInfo}. Please add it via \`wrangler secret put ${url ? "UPSTASH_REDIS_REST_TOKEN" : "UPSTASH_REDIS_REST_URL"}\` and provide it as an argument to the \`Redis.fromEnv\` function. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
+        `[Upstash Redis] Unable to find environment variable${plural ? "s" : ""}: ${names}. Please add ${plural ? "them" : "it"} via ${commands} and provide ${plural ? "them as arguments" : "it as an argument"} to the \`Redis.fromEnv\` function. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     }
     return new Redis({ ...opts, url, token }, env);

--- a/packages/redis/platforms/cloudflare.ts
+++ b/packages/redis/platforms/cloudflare.ts
@@ -56,7 +56,7 @@ export class Redis extends core.Redis {
   constructor(config: RedisConfigCloudflare, env?: Env) {
     if (!config.url) {
       console.warn(
-        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (config.url.startsWith(" ") || config.url.endsWith(" ") || /\r|\n/.test(config.url)) {
       console.warn(
@@ -66,7 +66,7 @@ export class Redis extends core.Redis {
 
     if (!config.token) {
       console.warn(
-        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (
       config.token.startsWith(" ") ||
@@ -151,7 +151,7 @@ export class Redis extends core.Redis {
 
     if (messageInfo) {
       console.warn(
-        `[Upstash Redis] ${messageInfo}. Please add it via \`wrangler secret put ${url ? "UPSTASH_REDIS_REST_TOKEN" : "UPSTASH_REDIS_REST_URL"}\` and provide it as an argument to the \`Redis.fromEnv\` function`
+        `[Upstash Redis] ${messageInfo}. Please add it via \`wrangler secret put ${url ? "UPSTASH_REDIS_REST_TOKEN" : "UPSTASH_REDIS_REST_URL"}\` and provide it as an argument to the \`Redis.fromEnv\` function. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     }
     return new Redis({ ...opts, url, token }, env);

--- a/packages/redis/platforms/fastly.ts
+++ b/packages/redis/platforms/fastly.ts
@@ -54,7 +54,7 @@ export class Redis extends core.Redis {
   constructor(config: RedisConfigFastly) {
     if (!config.url) {
       console.warn(
-        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (config.url.startsWith(" ") || config.url.endsWith(" ") || /\r|\n/.test(config.url)) {
       console.warn(
@@ -64,7 +64,7 @@ export class Redis extends core.Redis {
 
     if (!config.token) {
       console.warn(
-        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (
       config.token.startsWith(" ") ||

--- a/packages/redis/platforms/nodejs.ts
+++ b/packages/redis/platforms/nodejs.ts
@@ -107,7 +107,7 @@ export class Redis extends core.Redis {
 
     if (!configOrRequester.url) {
       console.warn(
-        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'url' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (
       configOrRequester.url.startsWith(" ") ||
@@ -121,7 +121,7 @@ export class Redis extends core.Redis {
 
     if (!configOrRequester.token) {
       console.warn(
-        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config.`
+        `[Upstash Redis] The 'token' property is missing or undefined in your Redis config. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis`
       );
     } else if (
       configOrRequester.token.startsWith(" ") ||
@@ -210,13 +210,15 @@ export class Redis extends core.Redis {
 
     const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
     if (!url) {
-      console.warn("[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_URL`");
+      console.warn(
+        "[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_URL`. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis"
+      );
     }
 
     const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
     if (!token) {
       console.warn(
-        "[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_TOKEN`"
+        "[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_TOKEN`. To create a database instantly (no signup needed), run: curl -X POST https://upstash.com/start-redis"
       );
     }
     return new Redis({ ...config, url, token });


### PR DESCRIPTION
## Summary
When the Redis client is constructed without a `url` or `token` (or `fromEnv` can't find `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`), the warning now also tells the user how to get a database immediately: `curl -X POST https://upstash.com/start-redis` — a zero-config, no-signup way to provision an Upstash Redis database.

## Changes
- `platforms/nodejs.ts`: tip appended to the constructor missing-url/token warnings and both `fromEnv` missing-env-var warnings
- `platforms/cloudflare.ts`: tip appended to the constructor warnings and the `fromEnv` wrangler guidance
- `platforms/fastly.ts`: tip appended to the constructor warnings

Whitespace/newline warnings are unchanged since those users already have credentials.