### PR TITLE
DX-2861: deduplicate telemetry header values

### DIFF
--- a/.changeset/dedupe-telemetry-headers.md
+++ b/.changeset/dedupe-telemetry-headers.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": patch
+---
+
+Deduplicate telemetry header values so repeated `mergeTelemetry` calls no longer append the same sdk, platform or runtime tag multiple times

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -212,4 +212,37 @@ describe("http", () => {
       server.stop(true);
     }
   });
+
+  describe("mergeTelemetry", () => {
+    test("appends distinct values", () => {
+      const client = new HttpClient({
+        baseUrl: SERVER_URL,
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      client.mergeTelemetry({ sdk: "@upstash/redis@1.0.0", runtime: "node@v20" });
+      client.mergeTelemetry({ sdk: "@upstash/ratelimit@2.0.0" });
+
+      expect(client.headers["Upstash-Telemetry-Sdk"]).toBe(
+        "@upstash/redis@1.0.0,@upstash/ratelimit@2.0.0"
+      );
+      expect(client.headers["Upstash-Telemetry-Runtime"]).toBe("node@v20");
+    });
+
+    test("does not duplicate values on repeated calls", () => {
+      const client = new HttpClient({
+        baseUrl: SERVER_URL,
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      client.mergeTelemetry({ sdk: "@upstash/redis@1.0.0", platform: "vercel" });
+      client.mergeTelemetry({ sdk: "@upstash/ratelimit@2.0.0" });
+      client.mergeTelemetry({ sdk: "@upstash/ratelimit@2.0.0", platform: "vercel" });
+
+      expect(client.headers["Upstash-Telemetry-Sdk"]).toBe(
+        "@upstash/redis@1.0.0,@upstash/ratelimit@2.0.0"
+      );
+      expect(client.headers["Upstash-Telemetry-Platform"]).toBe("vercel");
+    });
+  });
 });

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -450,6 +450,14 @@ function merge(obj: Record<string, string>, key: string, value?: string): Record
   if (!value) {
     return obj;
   }
-  obj[key] = obj[key] ? [obj[key], value].join(",") : value;
+  if (!obj[key]) {
+    obj[key] = value;
+    return obj;
+  }
+  const values = obj[key].split(",");
+  if (!values.includes(value)) {
+    values.push(value);
+    obj[key] = values.join(",");
+  }
   return obj;
 }


### PR DESCRIPTION
## Summary
`mergeTelemetry` appended every value to the telemetry headers unconditionally, so repeated calls with the same value (e.g. several `Ratelimit` instances sharing one redis client, or repeated `addTelemetry` calls) stacked duplicates like `@upstash/ratelimit@2.0.6,@upstash/ratelimit@2.0.6,...` in `Upstash-Telemetry-Sdk`. The `merge` helper now skips values already present in the header.

## Changes
- `packages/redis/pkg/http.ts`: `merge` splits the existing header on `,` and only appends values not already present
- `packages/redis/pkg/http.test.ts`: unit tests for distinct-value append and repeated-call dedup
- patch changeset

## Testing
- `bun test pkg/http.test.ts`: 8 pass (mock servers only, no live redis)
- eslint and build clean